### PR TITLE
feat: support ZodPipe, ZodDefault, and ZodCatch

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,13 +3,16 @@ import {
 	ZodArray,
 	ZodBigInt,
 	ZodBoolean,
+	ZodCatch,
 	ZodDate,
+	ZodDefault,
 	ZodEnum,
 	ZodMap,
 	ZodNullable,
 	ZodNumber,
 	ZodObject,
 	ZodOptional,
+	ZodPipe,
 	ZodSet,
 	ZodString,
 	ZodTuple,
@@ -196,6 +199,30 @@ const traverseKey = ({
 			messages,
 			enums,
 			isOptional: true,
+			isInArray,
+			typePrefix
+		})
+	}
+
+	if (value instanceof ZodPipe) {
+		return traverseKey({
+			key,
+			value: value._def.in,
+			messages,
+			enums,
+			isOptional,
+			isInArray,
+			typePrefix
+		})
+	}
+
+	if (value instanceof ZodDefault || value instanceof ZodCatch) {
+		return traverseKey({
+			key,
+			value: value._def.innerType,
+			messages,
+			enums,
+			isOptional,
 			isInArray,
 			typePrefix
 		})

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -651,4 +651,109 @@ message Message {
 		const proto = zodToProtobuf(schema)
 		expect(proto).toBe(expectedProto)
 	})
+
+	it('should handle transform', () => {
+		const schema = z.object({
+			name: z.string().transform((val) => val.toUpperCase())
+		})
+
+		const expectedProto = `
+syntax = "proto3";
+package default;
+
+message Message {
+    string name = 1;
+}`
+
+		const proto = zodToProtobuf(schema)
+		expect(proto).toBe(expectedProto.trim())
+	})
+
+	it('should handle chained transforms', () => {
+		const schema = z.object({
+			name: z
+				.string()
+				.transform((val) => val.trim())
+				.transform((val) => val.toUpperCase())
+		})
+
+		const expectedProto = `
+syntax = "proto3";
+package default;
+
+message Message {
+    string name = 1;
+}`
+
+		const proto = zodToProtobuf(schema)
+		expect(proto).toBe(expectedProto.trim())
+	})
+
+	it('should handle explicit pipe', () => {
+		const schema = z.object({
+			name: z.string().pipe(z.number())
+		})
+
+		const expectedProto = `
+syntax = "proto3";
+package default;
+
+message Message {
+    string name = 1;
+}`
+
+		const proto = zodToProtobuf(schema)
+		expect(proto).toBe(expectedProto.trim())
+	})
+
+	it('should handle default', () => {
+		const schema = z.object({
+			name: z.string().default('hello')
+		})
+
+		const expectedProto = `
+syntax = "proto3";
+package default;
+
+message Message {
+    string name = 1;
+}`
+
+		const proto = zodToProtobuf(schema)
+		expect(proto).toBe(expectedProto.trim())
+	})
+
+	it('should handle optional with default', () => {
+		const schema = z.object({
+			name: z.string().optional().default('hello')
+		})
+
+		const expectedProto = `
+syntax = "proto3";
+package default;
+
+message Message {
+    optional string name = 1;
+}`
+
+		const proto = zodToProtobuf(schema)
+		expect(proto).toBe(expectedProto.trim())
+	})
+
+	it('should handle catch', () => {
+		const schema = z.object({
+			name: z.string().catch('fallback')
+		})
+
+		const expectedProto = `
+syntax = "proto3";
+package default;
+
+message Message {
+    string name = 1;
+}`
+
+		const proto = zodToProtobuf(schema)
+		expect(proto).toBe(expectedProto.trim())
+	})
 })


### PR DESCRIPTION
Unwrap `ZodPipe`, `ZodDefault`, and `ZodCatch` to their inner schemas during protobuf conversion, following the existing pattern for `ZodOptional`/`ZodNullable`. `ZodPipe` (created by `.transform()` and `.pipe()`) resolves to its input type since protobuf describes the wire format. `ZodDefault` and `ZodCatch` pass through to their inner type without affecting optionality.

Closes #4. Closes #5.