### PR TITLE
ci: enforce conventional commits via PR title gate

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -1,0 +1,32 @@
+name: PR Gate
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  conventional-commit:
+    name: Conventional commit title
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enforce Conventional Commits
+        uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            chore
+            docs
+            style
+            refactor
+            perf
+            test
+            build
+            ci
+            revert
+          requireSubject: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,3 +44,10 @@ No lockfile is generated (`.npmrc` has `package-lock=false`). Dependencies are p
 - Target branch: `master`
 - All checks must pass: lint, format, tests, build
 - Run `npm run validate` before submitting
+
+## Commit & Release Conventions
+
+- **All commits and PR titles must follow [Conventional Commits](https://www.conventionalcommits.org/)**: `type(scope): subject`, where `type` is one of `feat`, `fix`, `chore`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `revert`. Use `!` or a `BREAKING CHANGE:` footer for breaking changes.
+- This convention is enforced by the **PR Gate** workflow (`.github/workflows/pr-gate.yml`), which fails any PR whose title does not conform.
+- Releases are automated by [release-please](https://github.com/googleapis/release-please-action): merging Conventional Commits to `master` opens a release PR titled `chore(master): release ...`; merging it tags and publishes the release.
+- `CLAUDE.md` is a symlink to this file so Claude Code reads the same conventions.


### PR DESCRIPTION
Adds a **PR Gate** workflow that fails any PR whose title is not a Conventional Commit (`type(scope): subject`), and documents the convention in `AGENTS.md` (`CLAUDE.md` is symlinked to it). Required for release-please to generate releases correctly.