### PR TITLE
ci: enforce formatting only via pre-commit hook

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -29,9 +29,6 @@ jobs:
       - name: Lint project
         run: npm run lint
 
-      - name: Check formatting
-        run: npm run format:check
-
       - name: Run tests
         run: npm run test
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,14 +21,13 @@ No lockfile is generated (`.npmrc` has `package-lock=false`). Dependencies are p
 
 ## Development Commands
 
-| Command                | Description                       |
-| ---------------------- | --------------------------------- |
-| `npm run build`        | Compile TypeScript to `dist/`     |
-| `npm run lint`         | Run oxlint with type-aware checks |
-| `npm run format`       | Format with oxfmt (write mode)    |
-| `npm run format:check` | Check formatting without writing  |
-| `npm test`             | Run Vitest in watch mode          |
-| `npm run validate`     | Lint + format check + tests (CI)  |
+| Command            | Description                       |
+| ------------------ | --------------------------------- |
+| `npm run build`    | Compile TypeScript to `dist/`     |
+| `npm run lint`     | Run oxlint with type-aware checks |
+| `npm run format`   | Format with oxfmt (write mode)    |
+| `npm test`         | Run Vitest in watch mode          |
+| `npm run validate` | Lint + tests (CI)                 |
 
 ## Testing
 
@@ -42,7 +41,8 @@ No lockfile is generated (`.npmrc` has `package-lock=false`). Dependencies are p
 ## PR Guidelines
 
 - Target branch: `master`
-- All checks must pass: lint, format, tests, build
+- All CI checks must pass: lint, tests, build
+- Formatting is enforced locally by the git pre-commit hook (`.githooks/pre-commit`), not in CI; it runs `oxfmt --write` plus `oxlint --fix` on commit
 - Run `npm run validate` before submitting
 
 ## Commit & Release Conventions

--- a/package.json
+++ b/package.json
@@ -37,10 +37,9 @@
 		"start": "node dist/index.js",
 		"lint": "oxlint --type-aware",
 		"format": "oxfmt --write",
-		"format:check": "oxfmt --check",
 		"prepare": "git config core.hooksPath .githooks",
 		"test": "bun test",
-		"validate": "npm run lint && npm run format:check && npm run test"
+		"validate": "npm run lint && npm run test"
 	},
 	"dependencies": {
 		"inflection": "3.0.2"


### PR DESCRIPTION
Stop enforcing formatting in CI; formatting is now enforced solely by the git pre-commit hook (`.githooks/pre-commit`, which runs `oxfmt --write` plus `oxlint --fix`).

- Remove the "Check formatting" step from `.github/workflows/pr.yml`
- Remove the `format:check` script and drop it from `validate` in `package.json`
- Update AGENTS.md command table and PR guidelines accordingly

Verified: `bun install && npm run lint && npm test && npm run build` all pass.