### PR TITLE
build: enforce strict oxlint config with anti-slop rules and harden src/index.ts

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,14 +1,317 @@
 {
 	"$schema": "./node_modules/oxlint/configuration_schema.json",
-	"plugins": ["typescript", "unicorn", "oxc", "import"],
-	"categories": {
-		"correctness": "error"
+	"plugins": ["typescript", "oxc", "unicorn", "import", "promise"],
+	"jsPlugins": [
+		{
+			"name": "anti-slop",
+			// ultracite bundles the anti-slop plugin (upstream dmmulroy/anti-slop is
+			// copy-the-source, not published to npm). plugin.mjs is not in ultracite's
+			// exports map, so the specifier has to be a path.
+			"specifier": "./node_modules/ultracite/config/oxlint/anti-slop/plugin.mjs"
+		}
+	],
+	"options": {
+		// A disable directive that suppresses nothing is a lie about the code it sits on.
+		// Denying them keeps stale suppressions from accumulating now that oxlint owns the
+		// rule set. When a rule here is turned off or renamed, its directives have to go in
+		// the same change.
+		"reportUnusedDisableDirectives": "deny"
 	},
+	"categories": {
+		"correctness": "error",
+		// Clean at these levels for a pure library module with no React, no DOM, and no
+		// async I/O. `pedantic` stays off; its style policing buys nothing here.
+		"suspicious": "error",
+		"perf": "error"
+	},
+	"env": {
+		"node": true,
+		"es2024": true,
+		"builtin": true
+	},
+	"ignorePatterns": ["dist/**", "node_modules/**"],
 	"rules": {
+		"eqeqeq": "error",
+		// The library is synchronous; an await inside a loop is either a serialisation bug
+		// or dead code. Kept on so it stays that way.
+		"no-await-in-loop": "error",
+		"array-callback-return": "error",
+		"no-duplicate-imports": "error",
+		"no-eq-null": "error",
+		"no-promise-executor-return": "error",
+		"no-useless-concat": "error",
+		"object-shorthand": "error",
+		"radix": "error",
+		"no-label-var": "error",
+		"no-self-compare": "error",
+		"no-template-curly-in-string": "error",
+		"default-case-last": "error",
+		"no-unneeded-ternary": "error",
+		"no-useless-rename": "error",
+		"no-lone-blocks": "error",
+		"no-sequences": "error",
+		"prefer-const": "error",
+		"prefer-exponentiation-operator": "error",
+		"no-var": "error",
+		"prefer-object-spread": "error",
+		"preserve-caught-error": "error",
+		"block-scoped-var": "error",
+		"guard-for-in": "error",
+		"no-case-declarations": "error",
+		"no-constructor-return": "error",
+		"no-empty": "error",
+		"no-extend-native": "error",
+		"no-fallthrough": "error",
+		"no-implied-eval": "error",
+		"no-labels": "error",
+		"no-loop-func": "error",
+		"no-multi-str": "error",
+		"no-new-func": "error",
+		"no-new-wrappers": "error",
+		"no-object-constructor": "error",
+		"no-proto": "error",
+		"no-prototype-builtins": "error",
+		"no-regex-spaces": "error",
+		"no-return-assign": "error",
+		"no-self-assign": "error",
+		"no-shadow": "error",
+		"no-unmodified-loop-condition": "error",
+		"no-unreachable-loop": "error",
+		"no-useless-call": "error",
+		"prefer-object-has-own": "error",
+		"prefer-regex-literals": "error",
+		// `multi-line` only: a brace-less body on its own line is a footgun, because oxfmt breaks
+		// a long single-line `if` at printWidth without adding braces. One-line `if (x) return y`
+		// stays legal.
+		"curly": ["error", "multi-line"],
+		"no-unexpected-multiline": "off",
+		"no-else-return": ["error", { "allowElseIf": false }],
+		"no-lonely-if": "error",
+		"no-nested-ternary": "error",
 		"no-param-reassign": "error",
+		"prefer-destructuring": ["error", { "array": false }],
+		"prefer-template": "error",
 		"default-param-last": "error",
-		"typescript/prefer-as-const": "error",
-		"typescript/prefer-enum-initializers": "error",
-		"typescript/no-inferrable-types": "error"
+		"no-unused-vars": ["error", { "argsIgnorePattern": "^_" }],
+		"no-console": ["error", { "allow": ["warn", "error"] }],
+		// Module-level helpers are declarations, not arrow assignments: declaration hoisting
+		// keeps the mutually recursive traversal family (traverseKey <-> traverseArray/
+		// traverseMap/traverseSchema) readable without caring about definition order.
+		"func-style": ["error", "declaration"],
+
+		"@typescript-eslint/ban-ts-comment": [
+			"error",
+			{ "minimumDescriptionLength": 10 }
+		],
+		"no-array-constructor": "error",
+		"@typescript-eslint/no-duplicate-enum-values": "error",
+		"@typescript-eslint/no-dynamic-delete": "error",
+		"@typescript-eslint/no-empty-object-type": "error",
+		"@typescript-eslint/no-explicit-any": "error",
+		"@typescript-eslint/no-extra-non-null-assertion": "error",
+		"@typescript-eslint/no-extraneous-class": "error",
+		"@typescript-eslint/no-misused-new": "error",
+		"@typescript-eslint/no-namespace": "error",
+		"@typescript-eslint/no-non-null-asserted-nullish-coalescing": "error",
+		"@typescript-eslint/no-non-null-asserted-optional-chain": "error",
+		"@typescript-eslint/no-non-null-assertion": "error",
+		"@typescript-eslint/no-require-imports": "error",
+		"@typescript-eslint/no-this-alias": "error",
+		"@typescript-eslint/no-unnecessary-condition": "error",
+		"@typescript-eslint/no-unnecessary-type-constraint": "error",
+		"@typescript-eslint/no-unsafe-declaration-merging": "error",
+		"@typescript-eslint/no-unsafe-function-type": "error",
+		"no-unused-expressions": "error",
+		"no-useless-constructor": "error",
+		"@typescript-eslint/no-wrapper-object-types": "error",
+		"@typescript-eslint/prefer-as-const": "error",
+		"@typescript-eslint/prefer-literal-enum-member": "error",
+		"@typescript-eslint/prefer-namespace-keyword": "error",
+		"@typescript-eslint/require-await": "error",
+		"@typescript-eslint/triple-slash-reference": "error",
+		"@typescript-eslint/adjacent-overload-signatures": "error",
+		"@typescript-eslint/ban-tslint-comment": "error",
+		"@typescript-eslint/consistent-generic-constructors": "error",
+		"@typescript-eslint/consistent-indexed-object-style": ["error", "record"],
+		// "type" (not the default "interface"): every shape in this library is a plain data
+		// record; nothing here needs declaration merging or `implements`.
+		"@typescript-eslint/consistent-type-definitions": ["error", "type"],
+		"@typescript-eslint/consistent-type-imports": [
+			"error",
+			{ "prefer": "type-imports", "fixStyle": "inline-type-imports" }
+		],
+		"@typescript-eslint/no-confusing-non-null-assertion": "error",
+		"no-empty-function": "error",
+		"@typescript-eslint/prefer-enum-initializers": "error",
+		"@typescript-eslint/prefer-for-of": "error",
+		"@typescript-eslint/prefer-function-type": "error",
+		"@typescript-eslint/prefer-optional-chain": "error",
+		"@typescript-eslint/prefer-ts-expect-error": "error",
+		"@typescript-eslint/no-invalid-void-type": "error",
+		"@typescript-eslint/no-floating-promises": "error",
+		"@typescript-eslint/no-misused-promises": "error",
+		"@typescript-eslint/await-thenable": "error",
+		"@typescript-eslint/no-misused-spread": "error",
+		"@typescript-eslint/no-for-in-array": "error",
+		"@typescript-eslint/no-array-delete": "error",
+		"@typescript-eslint/no-mixed-enums": "error",
+		"@typescript-eslint/no-duplicate-type-constituents": "error",
+		// Type-aware: flags enum-vs-literal comparisons where the literal is not a member,
+		// which is exactly the drift a renamed enum member leaves behind.
+		"@typescript-eslint/no-unsafe-enum-comparison": "error",
+		"@typescript-eslint/unbound-method": "error",
+		"@typescript-eslint/no-base-to-string": "error",
+		// The eslint-core no-return-await does not exist in oxlint 1.x; return-await
+		// below with "never" covers it.
+		"@typescript-eslint/return-await": ["error", "never"],
+		"@typescript-eslint/switch-exhaustiveness-check": "error",
+		// The converter composes proto type strings from known parts; anything string +
+		// non-string is a bug worth catching at review time.
+		"@typescript-eslint/restrict-plus-operands": "error",
+		"@typescript-eslint/require-array-sort-compare": "error",
+		"@typescript-eslint/no-unnecessary-boolean-literal-compare": "error",
+		"@typescript-eslint/use-unknown-in-catch-callback-variable": "error",
+		"@typescript-eslint/no-unnecessary-template-expression": "error",
+		// no-unnecessary-type-assertion stays off. Under oxlint-tsgolint 7.x it is at least
+		// deterministic, but the pre-commit hook runs `oxlint --fix`, and a false positive
+		// here silently strips a cast the type checker still needs. Re-evaluate on upgrade;
+		// no-widen-then-assert plus require-safety-comment-for-type-assertion cover the
+		// important half of what it would catch.
+		"@typescript-eslint/no-unnecessary-type-arguments": "error",
+
+		"unicorn/catch-error-name": "error",
+		"unicorn/consistent-existence-index-check": "error",
+		"unicorn/filename-case": "error",
+		"unicorn/new-for-builtins": "error",
+		"unicorn/no-abusive-eslint-disable": "error",
+		"unicorn/no-await-expression-member": "error",
+		"unicorn/no-empty-file": "error",
+		// strict, not the default loose strategy: loose skips `Error` itself, which is the
+		// one builtin hand-rolled probes reach for most often.
+		"unicorn/no-instanceof-builtins": ["error", { "strategy": "strict" }],
+		"unicorn/no-negated-condition": "error",
+		"unicorn/no-new-array": "error",
+		"unicorn/no-thenable": "error",
+		"unicorn/no-typeof-undefined": "error",
+		"unicorn/no-useless-fallback-in-spread": "error",
+		"unicorn/no-useless-promise-resolve-reject": "error",
+		"unicorn/no-useless-spread": "error",
+		"unicorn/no-useless-switch-case": "error",
+		"unicorn/no-useless-undefined": [
+			"error",
+			{ "checkArguments": false, "checkArrowFunctionBody": false }
+		],
+		"unicorn/no-zero-fractions": "error",
+		"unicorn/numeric-separators-style": "error",
+		"unicorn/prefer-array-find": "error",
+		"unicorn/prefer-array-flat-map": "error",
+		"unicorn/prefer-array-some": "error",
+		"unicorn/prefer-date-now": "error",
+		"unicorn/prefer-logical-operator-over-ternary": "error",
+		"unicorn/prefer-native-coercion-functions": "error",
+		"unicorn/prefer-number-properties": "error",
+		"unicorn/prefer-object-from-entries": "error",
+		"unicorn/prefer-regexp-test": "error",
+		"unicorn/prefer-set-has": "error",
+		"unicorn/prefer-spread": "error",
+		"unicorn/prefer-string-replace-all": "error",
+		"unicorn/prefer-string-slice": "error",
+		"unicorn/require-array-join-separator": "error",
+		"unicorn/switch-case-braces": "error",
+		"unicorn/text-encoding-identifier-case": "error",
+		"unicorn/consistent-empty-array-spread": "error",
+		"unicorn/error-message": "error",
+		"unicorn/no-accessor-recursion": "error",
+		"unicorn/no-array-fill-with-reference-type": "error",
+		"unicorn/no-array-sort": "error",
+		"unicorn/no-instanceof-array": "error",
+		"unicorn/no-length-as-slice-end": "error",
+		"unicorn/no-magic-array-flat-depth": "error",
+		"unicorn/no-negation-in-equality-check": "error",
+		"unicorn/no-object-as-default-parameter": "error",
+		"unicorn/no-unnecessary-await": "error",
+		"unicorn/no-unnecessary-slice-end": "error",
+		"unicorn/no-unreadable-array-destructuring": "error",
+		"unicorn/no-useless-length-check": "error",
+		"unicorn/prefer-math-min-max": "error",
+		"unicorn/prefer-modern-math-apis": "error",
+		"unicorn/prefer-set-size": "error",
+		"unicorn/prefer-type-error": "error",
+		"unicorn/require-number-to-fixed-digits-argument": "error",
+		"unicorn/throw-new-error": "error",
+
+		"import/consistent-type-specifier-style": ["error", "prefer-inline"],
+		"import/no-absolute-path": "error",
+		"import/no-cycle": "error",
+		"import/no-duplicates": "error",
+		"import/no-empty-named-blocks": "error",
+		"import/no-mutable-exports": "error",
+		"import/no-named-as-default": "error",
+		"import/no-self-import": "error",
+		"import/no-unassigned-import": "error",
+
+		"oxc/approx-constant": "error",
+		"oxc/bad-array-method-on-arguments": "error",
+		"oxc/bad-bitwise-operator": "error",
+		"oxc/bad-char-at-comparison": "error",
+		"oxc/bad-comparison-sequence": "error",
+		"oxc/bad-match-all-arg": "error",
+		"oxc/bad-min-max-func": "error",
+		"oxc/bad-object-literal-comparison": "error",
+		"oxc/bad-replace-all-arg": "error",
+		"oxc/branches-sharing-code": "error",
+		"oxc/const-comparisons": "error",
+		"oxc/double-comparisons": "error",
+		"oxc/erasing-op": "error",
+		"oxc/misrefactored-assign-op": "error",
+		"oxc/missing-throw": "error",
+		"oxc/no-accumulating-spread": "error",
+		"oxc/number-arg-out-of-range": "error",
+		"oxc/only-used-in-recursion": "error",
+		"oxc/uninvoked-array-callback": "error",
+
+		"promise/always-return": "error",
+		"promise/no-callback-in-promise": "error",
+		"promise/no-multiple-resolved": "error",
+		"promise/no-nesting": "error",
+		"promise/no-new-statics": "error",
+		"promise/no-promise-in-callback": "error",
+		"promise/no-return-wrap": "error",
+		"promise/param-names": "error",
+		"promise/prefer-catch": "error",
+		"promise/spec-only": "error",
+		"promise/valid-params": "error",
+
+		// anti-slop (upstream dmmulroy/anti-slop, vendored by ultracite).
+		"anti-slop/no-chained-type-assertions": "error",
+		"anti-slop/no-conditional-empty-object-spread": "error",
+		// On with suspicion: the fixer rewrites `...(x === undefined ? {} : { k: x })`
+		// into a bare `k: x`, which turns "key absent" into "key present, value undefined".
+		// oxlint applies plugin fixes even at `warn`, and `oxlint --fix` runs in the
+		// pre-commit hook, so if this ever fires, fix the site by hand and check the diff
+		// rather than accepting the fixer's.
+		"anti-slop/no-known-value-widening": "error",
+		// Tests never run against real modules here; there is nothing to mock. The rule
+		// targets vi.mock/jest.mock calls that do not exist in a bun test suite either way,
+		// but keeping it on means a future migration to a mockable runner cannot regress.
+		"anti-slop/no-module-mocking": "error",
+		"anti-slop/no-object-parameters": "error",
+		"anti-slop/no-reflect-apply": "error",
+		"anti-slop/no-reflect-get": "error",
+		"anti-slop/no-runtime-typeof": "error",
+		// Deliberately off: the rule reports on ANY identifier containing the
+		// substring "shape", including plain member access. This library walks
+		// zod v4 schemas, and `schema.shape` is zod's official, un-renameable
+		// accessor for object fields -- so keeping the rule on means one inline
+		// disable per `.shape` read forever, not slop prevention. The two
+		// "shape" identifiers that exist here are exactly that accessor plus a
+		// test fixture key mirroring it.
+		"anti-slop/no-shape-in-symbol-names": "off",
+		"anti-slop/no-unknown-parameters": "error",
+		"anti-slop/no-unknown-returns": "error",
+		"anti-slop/no-unknown-type-aliases": "error",
+		"anti-slop/no-unsafe-dictionary-type": "error",
+		"anti-slop/no-widen-then-assert": "error",
+		"anti-slop/require-safety-comment-for-type-assertion": "error"
 	}
 }

--- a/bun.lock
+++ b/bun.lock
@@ -13,6 +13,7 @@
         "oxlint": "catalog:",
         "oxlint-tsgolint": "catalog:",
         "typescript": "catalog:",
+        "ultracite": "7.10.6",
       },
       "peerDependencies": {
         "zod": "^4.0.0",
@@ -28,6 +29,24 @@
     "typescript": "7.0.2",
   },
   "packages": {
+    "@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
+
+    "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+
+    "@babel/parser": ["@babel/parser@7.29.8", "", { "dependencies": { "@babel/types": "^7.29.8" }, "bin": "./bin/babel-parser.js" }, "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA=="],
+
+    "@babel/types": ["@babel/types@7.29.8", "", { "dependencies": { "@babel/helper-string-parser": "^7.29.7", "@babel/helper-validator-identifier": "^7.29.7" } }, "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg=="],
+
+    "@clack/core": ["@clack/core@1.4.3", "", { "dependencies": { "fast-wrap-ansi": "^0.2.0", "sisteransi": "^1.0.5" } }, "sha512-/kr3UWNtdJfxZtPgDqUOmG2pvwlmcLGheex5yiZKdwbzZJxhV+HMNR9QNmyY5cGwTNV6LrR7Jtp+KjhUAP1qBQ=="],
+
+    "@clack/prompts": ["@clack/prompts@1.7.0", "", { "dependencies": { "@clack/core": "1.4.3", "fast-string-width": "^3.0.2", "fast-wrap-ansi": "^0.2.0", "sisteransi": "^1.0.5" } }, "sha512-y7/yvZ2TPAnR9+jnc00klvNNLkJiXFFrQA/hlLCcxA9a2A4zQIOimyFQ9XfwYKiGD1fb5GY8vbKIIgO8d5Tb2A=="],
+
+    "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
+
+    "@nodelib/fs.stat": ["@nodelib/fs.stat@2.0.5", "", {}, "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A=="],
+
+    "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
+
     "@oxfmt/binding-android-arm-eabi": ["@oxfmt/binding-android-arm-eabi@0.64.0", "", { "os": "android", "cpu": "arm" }, "sha512-o6uzh/jTOQeAY5TdkAeXdqv7MBRcPxiRA08zrcBtkKj5cSu/FMu0Hl7Q6Fi1KCKyCWZ6lJVjBzdsJvsKltUsGQ=="],
 
     "@oxfmt/binding-android-arm64": ["@oxfmt/binding-android-arm64@0.64.0", "", { "os": "android", "cpu": "arm64" }, "sha512-jRGSUeeP7p3Gynw2YaCVtjBIA6ZxY6bEB/ES5i54OhqmRTyuVg7ZgstEtzgq6GOAJd+2QZ5pvf+bFfmW5Mp9cw=="],
@@ -116,6 +135,10 @@
 
     "@oxlint/binding-win32-x64-msvc": ["@oxlint/binding-win32-x64-msvc@1.79.0", "", { "os": "win32", "cpu": "x64" }, "sha512-mEelcCMMBS57sIXh2veGMNy+pQwuGtcMxHxGIZWQ5Ba9pJ5jCCUFOZB9E2JhBaxGsURe+WGe0zJp4RVre52gpQ=="],
 
+    "@sec-ant/readable-stream": ["@sec-ant/readable-stream@0.4.1", "", {}, "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg=="],
+
+    "@sindresorhus/merge-streams": ["@sindresorhus/merge-streams@4.0.0", "", {}, "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ=="],
+
     "@types/node": ["@types/node@26.2.0", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg=="],
 
     "@typescript/typescript-aix-ppc64": ["@typescript/typescript-aix-ppc64@7.0.2", "", { "os": "aix", "cpu": "ppc64" }, "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ=="],
@@ -158,7 +181,93 @@
 
     "@typescript/typescript-win32-x64": ["@typescript/typescript-win32-x64@7.0.2", "", { "os": "win32", "cpu": "x64" }, "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g=="],
 
+    "acorn": ["acorn@8.18.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ=="],
+
+    "ansi-escapes": ["ansi-escapes@7.3.0", "", { "dependencies": { "environment": "^1.0.0" } }, "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg=="],
+
+    "ansi-regex": ["ansi-regex@6.3.0", "", {}, "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ=="],
+
+    "ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
+
+    "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
+
+    "citty": ["citty@0.2.2", "", {}, "sha512-+6vJA3L98yv+IdfKGZHBNiGW5KHn22e/JwID0Strsz8h4S/csAu/OuICwxrg44k5MRiZHWIo8XXuJgQTriRP4w=="],
+
+    "cli-cursor": ["cli-cursor@5.0.0", "", { "dependencies": { "restore-cursor": "^5.0.0" } }, "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw=="],
+
+    "cli-truncate": ["cli-truncate@6.1.1", "", { "dependencies": { "slice-ansi": "^9.0.0", "string-width": "^8.2.0" } }, "sha512-06p9vyLahLa4zkGcgsGxU6iEkSOiuI4fhCH6Emhe2lPAcoUv73n72DnODsnHA+5wwXGnV0n9M9/qOQJSjYhFhw=="],
+
+    "commander": ["commander@15.0.0", "", {}, "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg=="],
+
+    "confbox": ["confbox@0.1.8", "", {}, "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w=="],
+
+    "deepmerge": ["deepmerge@4.3.1", "", {}, "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A=="],
+
+    "empathic": ["empathic@2.0.1", "", {}, "sha512-YGRs8knHhKHVShLkFET/rWAU8kmHbOV5LwN938RHI0pljAJ1Gf6SzXsSmRaEzcXTtOOmVqJ5+WtQPL5uigY50Q=="],
+
+    "environment": ["environment@1.1.0", "", {}, "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q=="],
+
+    "execa": ["execa@10.0.1", "", { "dependencies": { "@sindresorhus/merge-streams": "^4.0.0", "figures": "^6.1.0", "get-stream": "^9.0.1", "human-signals": "^8.0.1", "is-plain-obj": "^4.1.0", "is-stream": "^4.0.1", "npm-run-path": "^6.0.0", "pretty-ms": "^9.3.0", "signal-exit": "^4.1.0", "strip-final-newline": "^4.0.0", "which-command": "^0.1.0", "yoctocolors": "^2.1.2" } }, "sha512-ge98qjkRK4IB7tL7Ju/6qmm5LHoH1eEMt5FNZrz3f4UIYhF28lggX20z3FaX1sgc67msLEn0N0BscOs29iuwyw=="],
+
+    "fast-glob": ["fast-glob@3.3.3", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.8" } }, "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg=="],
+
+    "fast-string-truncated-width": ["fast-string-truncated-width@3.0.3", "", {}, "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g=="],
+
+    "fast-string-width": ["fast-string-width@3.0.2", "", { "dependencies": { "fast-string-truncated-width": "^3.0.2" } }, "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg=="],
+
+    "fast-wrap-ansi": ["fast-wrap-ansi@0.2.2", "", { "dependencies": { "fast-string-width": "^3.0.2" } }, "sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q=="],
+
+    "fastq": ["fastq@1.20.1", "", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw=="],
+
+    "figures": ["figures@6.1.0", "", { "dependencies": { "is-unicode-supported": "^2.0.0" } }, "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg=="],
+
+    "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
+
+    "find-workspaces": ["find-workspaces@0.3.1", "", { "dependencies": { "fast-glob": "^3.3.2", "pkg-types": "^1.0.3", "yaml": "^2.3.4" } }, "sha512-UDkGILGJSA1LN5Aa7McxCid4sqW3/e+UYsVwyxki3dDT0F8+ym0rAfnCkEfkL0rO7M+8/mvkim4t/s3IPHmg+w=="],
+
+    "get-east-asian-width": ["get-east-asian-width@1.6.0", "", {}, "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA=="],
+
+    "get-stream": ["get-stream@9.0.1", "", { "dependencies": { "@sec-ant/readable-stream": "^0.4.1", "is-stream": "^4.0.1" } }, "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA=="],
+
+    "glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
+
+    "human-signals": ["human-signals@8.0.1", "", {}, "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ=="],
+
     "inflection": ["inflection@3.0.2", "", {}, "sha512-+Bg3+kg+J6JUWn8J6bzFmOWkTQ6L/NHfDRSYU+EVvuKHDxUDHAXgqixHfVlzuBQaPOTac8hn43aPhMNk6rMe3g=="],
+
+    "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
+
+    "is-fullwidth-code-point": ["is-fullwidth-code-point@5.1.0", "", { "dependencies": { "get-east-asian-width": "^1.3.1" } }, "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ=="],
+
+    "is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
+
+    "is-number": ["is-number@7.0.0", "", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
+
+    "is-plain-obj": ["is-plain-obj@4.1.0", "", {}, "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg=="],
+
+    "is-stream": ["is-stream@4.0.1", "", {}, "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A=="],
+
+    "is-unicode-supported": ["is-unicode-supported@2.1.0", "", {}, "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ=="],
+
+    "jsonc-parser": ["jsonc-parser@3.3.1", "", {}, "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ=="],
+
+    "log-update": ["log-update@8.0.0", "", { "dependencies": { "ansi-escapes": "^7.3.0", "cli-cursor": "^5.0.0", "slice-ansi": "^9.0.0", "string-width": "^8.2.0", "strip-ansi": "^7.2.0", "wrap-ansi": "^10.0.0" } }, "sha512-lddSgOt3bPASrylL54ZSpy8nBHns+vBVSoILlVOx+dei300pnLRN958rj/EdlVLKuWlSESU3qdnDZdAI7FXYGg=="],
+
+    "magicast": ["magicast@0.5.4", "", { "dependencies": { "@babel/parser": "^7.29.7", "@babel/types": "^7.29.7", "source-map-js": "^1.2.1" } }, "sha512-llBEhWm1SacoRwgHUoQJYtwp4PBLF4faQi5TCpIGyGs9n4y5+juI0tDgyKIfpqxckRHaHzouUEph3THklWh03w=="],
+
+    "merge2": ["merge2@1.4.1", "", {}, "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="],
+
+    "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
+
+    "mimic-function": ["mimic-function@5.0.1", "", {}, "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA=="],
+
+    "mlly": ["mlly@1.8.2", "", { "dependencies": { "acorn": "^8.16.0", "pathe": "^2.0.3", "pkg-types": "^1.3.1", "ufo": "^1.6.3" } }, "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA=="],
+
+    "npm-run-path": ["npm-run-path@6.0.0", "", { "dependencies": { "path-key": "^4.0.0", "unicorn-magic": "^0.3.0" } }, "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA=="],
+
+    "nypm": ["nypm@0.6.9", "", { "dependencies": { "citty": "^0.2.2", "pathe": "^2.0.3", "tinyexec": "^1.2.4" }, "bin": { "nypm": "./dist/cli.mjs" } }, "sha512-zxlE2yvSWZWmHcNdT3+5zV2lrCogeE9YOklHrR3dFjqutq5wO7GFDYLFDRXLsYnJzwvy/im9fYoxePvS0VTW0w=="],
+
+    "onetime": ["onetime@7.0.0", "", { "dependencies": { "mimic-function": "^5.0.0" } }, "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ=="],
 
     "oxfmt": ["oxfmt@0.64.0", "", { "dependencies": { "tinypool": "2.1.0" }, "optionalDependencies": { "@oxfmt/binding-android-arm-eabi": "0.64.0", "@oxfmt/binding-android-arm64": "0.64.0", "@oxfmt/binding-darwin-arm64": "0.64.0", "@oxfmt/binding-darwin-x64": "0.64.0", "@oxfmt/binding-freebsd-x64": "0.64.0", "@oxfmt/binding-linux-arm-gnueabihf": "0.64.0", "@oxfmt/binding-linux-arm-musleabihf": "0.64.0", "@oxfmt/binding-linux-arm64-gnu": "0.64.0", "@oxfmt/binding-linux-arm64-musl": "0.64.0", "@oxfmt/binding-linux-ppc64-gnu": "0.64.0", "@oxfmt/binding-linux-riscv64-gnu": "0.64.0", "@oxfmt/binding-linux-riscv64-musl": "0.64.0", "@oxfmt/binding-linux-s390x-gnu": "0.64.0", "@oxfmt/binding-linux-x64-gnu": "0.64.0", "@oxfmt/binding-linux-x64-musl": "0.64.0", "@oxfmt/binding-openharmony-arm64": "0.64.0", "@oxfmt/binding-win32-arm64-msvc": "0.64.0", "@oxfmt/binding-win32-ia32-msvc": "0.64.0", "@oxfmt/binding-win32-x64-msvc": "0.64.0" }, "peerDependencies": { "svelte": "^5.0.0", "vite-plus": "*" }, "optionalPeers": ["svelte", "vite-plus"], "bin": { "oxfmt": "bin/oxfmt" } }, "sha512-XZ4GFBN/PLbXKq+0zrgpQfPKYuJlUuj+nzZJY7UpIbFMNyefNLCdN9EwViycNqnYcv0wrn0jXcQLlqJp8RCKBg=="],
 
@@ -166,11 +275,65 @@
 
     "oxlint-tsgolint": ["oxlint-tsgolint@7.0.2001", "", { "optionalDependencies": { "@oxlint-tsgolint/darwin-arm64": "7.0.2001", "@oxlint-tsgolint/darwin-x64": "7.0.2001", "@oxlint-tsgolint/linux-arm64": "7.0.2001", "@oxlint-tsgolint/linux-x64": "7.0.2001", "@oxlint-tsgolint/win32-arm64": "7.0.2001", "@oxlint-tsgolint/win32-x64": "7.0.2001" }, "bin": { "tsgolint": "./bin/tsgolint.js" } }, "sha512-KjK/XLcXr1DSyonKhsuFqJRiuKqcyG9j3LJ8nkOsrLzGvodBPqzHOKauy10asLMDI0sUpvb+1sxlzff3udZvfg=="],
 
+    "parse-ms": ["parse-ms@4.0.0", "", {}, "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw=="],
+
+    "path-key": ["path-key@4.0.0", "", {}, "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ=="],
+
+    "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
+
+    "picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
+
+    "pkg-types": ["pkg-types@1.3.1", "", { "dependencies": { "confbox": "^0.1.8", "mlly": "^1.7.4", "pathe": "^2.0.1" } }, "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ=="],
+
+    "pretty-ms": ["pretty-ms@9.3.0", "", { "dependencies": { "parse-ms": "^4.0.0" } }, "sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ=="],
+
+    "queue-microtask": ["queue-microtask@1.2.3", "", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
+
+    "resolve.exports": ["resolve.exports@2.0.3", "", {}, "sha512-OcXjMsGdhL4XnbShKpAcSqPMzQoYkYyhbEaeSko47MjRP9NfEQMhZkXL1DoFlt9LWQn4YttrdnV6X2OiyzBi+A=="],
+
+    "restore-cursor": ["restore-cursor@5.1.0", "", { "dependencies": { "onetime": "^7.0.0", "signal-exit": "^4.1.0" } }, "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA=="],
+
+    "reusify": ["reusify@1.1.0", "", {}, "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="],
+
+    "run-parallel": ["run-parallel@1.2.0", "", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
+
+    "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
+
+    "sisteransi": ["sisteransi@1.0.5", "", {}, "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="],
+
+    "slice-ansi": ["slice-ansi@9.0.0", "", { "dependencies": { "ansi-styles": "^6.2.3", "is-fullwidth-code-point": "^5.1.0" } }, "sha512-SO/3iYL5S3W57LLEniscOGPZgOqZUPCx6d3dB+52B80yJ0XstzsC/eV8gnA4tM3MHDrKz+OCFSLNjswdSC+/bA=="],
+
+    "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
+
+    "string-width": ["string-width@8.2.2", "", { "dependencies": { "get-east-asian-width": "^1.5.0", "strip-ansi": "^7.1.2" } }, "sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg=="],
+
+    "strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
+
+    "strip-final-newline": ["strip-final-newline@4.0.0", "", {}, "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw=="],
+
+    "tinyexec": ["tinyexec@1.3.0", "", {}, "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ=="],
+
     "tinypool": ["tinypool@2.1.0", "", {}, "sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw=="],
+
+    "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
 
     "typescript": ["typescript@7.0.2", "", { "optionalDependencies": { "@typescript/typescript-aix-ppc64": "7.0.2", "@typescript/typescript-darwin-arm64": "7.0.2", "@typescript/typescript-darwin-x64": "7.0.2", "@typescript/typescript-freebsd-arm64": "7.0.2", "@typescript/typescript-freebsd-x64": "7.0.2", "@typescript/typescript-linux-arm": "7.0.2", "@typescript/typescript-linux-arm64": "7.0.2", "@typescript/typescript-linux-loong64": "7.0.2", "@typescript/typescript-linux-mips64el": "7.0.2", "@typescript/typescript-linux-ppc64": "7.0.2", "@typescript/typescript-linux-riscv64": "7.0.2", "@typescript/typescript-linux-s390x": "7.0.2", "@typescript/typescript-linux-x64": "7.0.2", "@typescript/typescript-netbsd-arm64": "7.0.2", "@typescript/typescript-netbsd-x64": "7.0.2", "@typescript/typescript-openbsd-arm64": "7.0.2", "@typescript/typescript-openbsd-x64": "7.0.2", "@typescript/typescript-sunos-x64": "7.0.2", "@typescript/typescript-win32-arm64": "7.0.2", "@typescript/typescript-win32-x64": "7.0.2" }, "bin": { "tsc": "bin/tsc" } }, "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA=="],
 
+    "ufo": ["ufo@1.6.4", "", {}, "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA=="],
+
+    "ultracite": ["ultracite@7.10.6", "", { "dependencies": { "@clack/prompts": "^1.5.1", "cli-truncate": "^6.1.1", "commander": "^15.0.0", "deepmerge": "^4.3.1", "empathic": "^2.0.1", "execa": "^10.0.1", "fast-glob": "^3.3.3", "find-workspaces": "^0.3.1", "jsonc-parser": "^3.3.1", "log-update": "^8.0.0", "magicast": "^0.5.4", "nypm": "^0.6.6", "resolve.exports": "^2.0.3", "string-width": "^8.2.2", "yaml": "^2.9.0", "zod": "^4.4.3" }, "peerDependencies": { "oxfmt": ">=0.1.0", "oxlint": "^1.79.0" }, "optionalPeers": ["oxfmt", "oxlint"], "bin": { "ultracite": "dist/index.js" } }, "sha512-kRoCy4z1A/rk0upPdIAJhOo4ocsUx9uTPsPcq3Z+xP1Bxg6dcKkwqX4siYJ1ba4z4kRbyxaEO4Zi5bw/iXZrFA=="],
+
     "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
+
+    "unicorn-magic": ["unicorn-magic@0.3.0", "", {}, "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA=="],
+
+    "which-command": ["which-command@0.1.0", "", { "bin": { "which-command": "cli.js" } }, "sha512-XZyoF5/5hZtXitIwzrU4NKK+Wtbb9aB9CezUEw2Q0wlYK8NUYQxC1rRXgNueYLtBAJwXIb+/tFVk4dozciNJMA=="],
+
+    "wrap-ansi": ["wrap-ansi@10.0.1", "", { "dependencies": { "ansi-styles": "^6.2.3", "string-width": "^8.2.0" } }, "sha512-M0N4xzyzosiIok3svYlEo1sdLZts/8FPgYH/GPC3wvlmPoRvnoManGMrE54waYj3tISA8w6lsdesfVv67qSr8Q=="],
+
+    "yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
+
+    "yoctocolors": ["yoctocolors@2.2.0", "", {}, "sha512-xYqdZFUK/VYazNl/oCDYN+3WloWQwMfZxBoiNt6qNyk+xfOdi598muWE42rNZFp1kNOiqW936q5RhUdnpqElSg=="],
 
     "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
   }

--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
 		"oxfmt": "catalog:",
 		"oxlint": "catalog:",
 		"oxlint-tsgolint": "catalog:",
-		"typescript": "catalog:"
+		"typescript": "catalog:",
+		"ultracite": "7.10.6"
 	},
 	"peerDependencies": {
 		"zod": "^4.0.0"

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,9 +42,18 @@ class UnsupportedTypeException extends Error {
 }
 
 type ProtobufField = {
-	types: Array<string | null>
+	types: string[]
 	name: string
 	oneofMembers?: ProtobufField[]
+}
+
+/** Shared state threaded through the whole conversion traversal. */
+type Context = {
+	messages: Map<string, string[]>
+	enums: Map<string, string[]>
+	typePrefix: string
+	useGoogleTimestamp: boolean
+	hasTimestamp: boolean
 }
 
 /**
@@ -52,7 +61,7 @@ type ProtobufField = {
  * @param value The ZodNumber instance.
  * @returns The Protobuf type name.
  */
-function getNumberTypeName({ value }: { value: ZodNumber }): string {
+function getNumberTypeName(value: ZodNumber): string {
 	return value.isInt ? 'int32' : 'double'
 }
 
@@ -61,7 +70,7 @@ function getNumberTypeName({ value }: { value: ZodNumber }): string {
  * @param value The string.
  * @returns The PascalCase string.
  */
-function toPascalCase({ value }: { value: string }): string {
+function toPascalCase(value: string): string {
 	return value
 		.split('.')
 		.map((part) => part.charAt(0).toUpperCase() + part.slice(1))
@@ -73,15 +82,15 @@ function toPascalCase({ value }: { value: string }): string {
  * @param value The string.
  * @returns The SCREAMING_SNAKE_CASE string.
  */
-function toScreamingSnakeCase({ value }: { value: string }): string {
+function toScreamingSnakeCase(value: string): string {
 	return value
 		.replaceAll(/([a-z0-9])([A-Z])/g, '$1_$2')
 		.replaceAll(/([A-Z])([A-Z][a-z])/g, '$1_$2')
 		.toUpperCase()
 }
 
-function protobufFieldToType({ field }: { field: ProtobufField }) {
-	return field.types.filter(Boolean).join(' ')
+function renderFieldType(field: ProtobufField): string {
+	return field.types.join(' ')
 }
 
 /**
@@ -90,7 +99,7 @@ function protobufFieldToType({ field }: { field: ProtobufField }) {
  * @param fields The ProtobufField array.
  * @returns An array of formatted field strings.
  */
-function formatFields({ fields }: { fields: ProtobufField[] }): string[] {
+function formatFields(fields: ProtobufField[]): string[] {
 	const lines: string[] = []
 	let fieldNum = 1
 	for (const field of fields) {
@@ -98,15 +107,13 @@ function formatFields({ fields }: { fields: ProtobufField[] }): string[] {
 			lines.push(`oneof ${field.name} {`)
 			for (const member of field.oneofMembers) {
 				lines.push(
-					`    ${protobufFieldToType({ field: member })} ${member.name} = ${fieldNum};`
+					`    ${renderFieldType(member)} ${member.name} = ${fieldNum};`
 				)
 				fieldNum++
 			}
 			lines.push('}')
 		} else {
-			lines.push(
-				`${protobufFieldToType({ field })} ${field.name} = ${fieldNum};`
-			)
+			lines.push(`${renderFieldType(field)} ${field.name} = ${fieldNum};`)
 			fieldNum++
 		}
 	}
@@ -118,9 +125,9 @@ function formatFields({ fields }: { fields: ProtobufField[] }): string[] {
  * @param value The Zod schema value.
  * @returns A short string suffix.
  */
-function getOneofTypeSuffix({ value }: { value: unknown }): string {
+function getOneofTypeSuffix(value: $ZodType): string {
 	if (value instanceof ZodString) return 'string'
-	if (value instanceof ZodNumber) return value.isInt ? 'int32' : 'double'
+	if (value instanceof ZodNumber) return getNumberTypeName(value)
 	if (value instanceof ZodBoolean) return 'bool'
 	if (value instanceof ZodBigInt) return 'int64'
 	if (value instanceof ZodDate) return 'date'
@@ -137,7 +144,7 @@ function getOneofTypeSuffix({ value }: { value: unknown }): string {
  * @param value The ZodLiteral instance.
  * @returns The Protobuf scalar type name.
  */
-function getLiteralTypeName({ value }: { value: ZodLiteral }): string {
+function getLiteralTypeName(value: ZodLiteral): string {
 	/* oxlint-disable anti-slop/no-runtime-typeof --
 	 * Discriminating a ZodLiteral by the JavaScript primitive type of its
 	 * held values IS this library's domain logic, not smuggled slop. proto3's
@@ -175,308 +182,146 @@ function toRepeatedField(field: ProtobufField, key: string): ProtobufField {
 }
 
 /**
- * Traverses an array schema and generates Protobuf fields.
- * Wraps nested arrays in messages to avoid invalid `repeated repeated`.
+ * Asserts a traversal produced exactly one plain field and returns it, so
+ * map/record sides can safely be rendered as a scalar map<...> entry.
+ */
+function soleField(fields: ProtobufField[], label: string): ProtobufField {
+	const [only] = fields
+	if (only === undefined || fields.length !== 1) {
+		throw new UnsupportedTypeException(label)
+	}
+	return only
+}
+
+/**
+ * Builds a `map<K, V>` field shared by the ZodMap and ZodRecord branches,
+ * validating that neither side flattens into more than one field.
+ */
+function toMapField(
+	context: Context,
+	key: string,
+	keyType: $ZodType,
+	valueType: $ZodType,
+	labelPrefix: 'map' | 'record'
+): ProtobufField {
+	const keyField = soleField(
+		traverseKey(`${key}Key`, keyType, false, true, context),
+		`${key} ${labelPrefix} key`
+	)
+	const valueField = soleField(
+		traverseKey(`${key}Value`, valueType, false, true, context),
+		`${key} ${labelPrefix} value`
+	)
+
+	return {
+		types: [
+			`map<${renderFieldType(keyField)}, ${renderFieldType(valueField)}>`
+		],
+		name: key
+	}
+}
+
+/**
+ * Traverses an array or set schema and generates Protobuf fields. Wraps
+ * nested arrays in messages to avoid invalid `repeated repeated`.
  * @param key The key for the array.
  * @param value The ZodArray or ZodSet instance.
- * @param messages The map of message definitions.
- * @param enums The map of enum definitions.
- * @param typePrefix The prefix for type names.
- * @param useGoogleTimestamp Whether to use google.protobuf.Timestamp for dates.
- * @param hasTimestamp Mutable ref tracking if Timestamp import is needed.
+ * @param context Shared traversal state.
  * @returns An array of Protobuf field definitions.
  */
-function traverseArray({
-	key,
-	value,
-	messages,
-	enums,
-	typePrefix,
-	useGoogleTimestamp,
-	hasTimestamp
-}: {
-	key: string
-	value: ZodArray | ZodSet
-	messages: Map<string, string[]>
-	enums: Map<string, string[]>
-	typePrefix: string | null
-	useGoogleTimestamp: boolean
-	hasTimestamp: { value: boolean }
-}): ProtobufField[] {
+function traverseArray(
+	key: string,
+	value: ZodArray | ZodSet,
+	context: Context
+): ProtobufField[] {
 	const nestedValue =
 		value instanceof ZodArray ? value.element : value.def.valueType
 
-	// Unwrap optional/nullable to check the underlying type
+	// Nested array/set: wrap inner array in a message to avoid invalid `repeated repeated`
 	let unwrapped: unknown = nestedValue
 	while (unwrapped instanceof ZodOptional || unwrapped instanceof ZodNullable) {
 		unwrapped = unwrapped.unwrap()
 	}
-
-	// Nested array/set: wrap inner array in a message to avoid invalid `repeated repeated`
 	if (unwrapped instanceof ZodArray || unwrapped instanceof ZodSet) {
 		const singularKey = inflection.singularize(key)
-		let wrapperName = `${toPascalCase({ value: singularKey })}List`
-		if (typePrefix) {
-			wrapperName = `${typePrefix}${wrapperName}`
-		}
+		let wrapperName = `${context.typePrefix}${toPascalCase(singularKey)}List`
 		// Avoid name collision with existing messages/enums
 		const baseName = wrapperName
 		let suffix = 2
-		while (messages.has(wrapperName) || enums.has(wrapperName)) {
+		while (
+			context.messages.has(wrapperName) ||
+			context.enums.has(wrapperName)
+		) {
 			wrapperName = `${baseName}${suffix}`
 			suffix++
 		}
 
-		const innerFields = traverseArray({
-			key: singularKey,
-			value: unwrapped,
-			messages,
-			enums,
-			typePrefix,
-			useGoogleTimestamp,
-			hasTimestamp
-		})
+		const innerFields = traverseArray(singularKey, unwrapped, context)
+		context.messages.set(wrapperName, formatFields(innerFields))
 
-		messages.set(wrapperName, formatFields({ fields: innerFields }))
-
-		return [
-			{
-				types: ['repeated', wrapperName],
-				name: key
-			}
-		]
+		return [{ types: ['repeated', wrapperName], name: key }]
 	}
 
 	const singularKey = inflection.singularize(key)
-	const elementFields = traverseKey({
-		key: singularKey,
-		value: nestedValue,
-		messages,
-		enums,
-		isOptional: false,
-		isInArray: true,
-		typePrefix,
-		useGoogleTimestamp,
-		hasTimestamp
-	})
+	const elementFields = traverseKey(
+		singularKey,
+		nestedValue,
+		false,
+		true,
+		context
+	)
 	return elementFields.map((field) => toRepeatedField(field, key))
-}
-
-/**
- * Traverses a map schema and generates Protobuf fields.
- * @param key The key for the map.
- * @param value The ZodMap instance.
- * @param messages The map of message definitions.
- * @param enums The map of enum definitions.
- * @param typePrefix The prefix for type names.
- * @param useGoogleTimestamp Whether to use google.protobuf.Timestamp for dates.
- * @param hasTimestamp Mutable ref tracking if Timestamp import is needed.
- * @returns An array of Protobuf field definitions.
- */
-function traverseMap({
-	key,
-	value,
-	messages,
-	enums,
-	typePrefix,
-	useGoogleTimestamp,
-	hasTimestamp
-}: {
-	key: string
-	value: ZodMap
-	messages: Map<string, string[]>
-	enums: Map<string, string[]>
-	typePrefix: string | null
-	useGoogleTimestamp: boolean
-	hasTimestamp: { value: boolean }
-}): ProtobufField[] {
-	const keyType = traverseKey({
-		key: `${key}Key`,
-		value: value.def.keyType,
-		messages,
-		enums,
-		isOptional: false,
-		isInArray: true,
-		typePrefix,
-		useGoogleTimestamp,
-		hasTimestamp
-	})
-	const valueType = traverseKey({
-		key: `${key}Value`,
-		value: value.def.valueType,
-		messages,
-		enums,
-		isOptional: false,
-		isInArray: true,
-		typePrefix,
-		useGoogleTimestamp,
-		hasTimestamp
-	})
-
-	if (!keyType[0] || keyType.length !== 1) {
-		throw new UnsupportedTypeException(`${key} map key`)
-	}
-
-	if (!valueType[0] || valueType.length !== 1) {
-		throw new UnsupportedTypeException(`${key} map value`)
-	}
-
-	const mapType = `map<${protobufFieldToType({ field: keyType[0] })}, ${protobufFieldToType({ field: valueType[0] })}>`
-	return [
-		{
-			types: [mapType],
-			name: key
-		}
-	]
 }
 
 /**
  * Traverses a key and its schema value to generate Protobuf fields.
  * @param key The key.
  * @param value The schema value.
- * @param messages The map of message definitions.
- * @param enums The map of enum definitions.
- * @param isOptional Whether the field is optional.
+ * @param isOptional Whether an enclosing optional/nullable made the field optional.
  * @param isInArray Whether the field is inside an array.
- * @param typePrefix The prefix for type names.
- * @param useGoogleTimestamp Whether to use google.protobuf.Timestamp for dates.
- * @param hasTimestamp Mutable ref tracking if Timestamp import is needed.
+ * @param context Shared traversal state.
  * @returns An array of Protobuf field definitions.
  */
-function traverseKey({
-	key,
-	value,
-	messages,
-	enums,
-	isOptional,
-	isInArray,
-	typePrefix,
-	useGoogleTimestamp,
-	hasTimestamp
-}: {
-	key: string
-	value: $ZodType
-	messages: Map<string, string[]>
-	enums: Map<string, string[]>
-	isOptional: boolean
-	isInArray: boolean
-	typePrefix: string | null
-	useGoogleTimestamp: boolean
-	hasTimestamp: { value: boolean }
-}): ProtobufField[] {
+function traverseKey(
+	key: string,
+	value: $ZodType,
+	isOptional: boolean,
+	isInArray: boolean,
+	context: Context
+): ProtobufField[] {
+	// Peels off wrappers that do not change the wire representation.
 	if (value instanceof ZodOptional || value instanceof ZodNullable) {
-		return traverseKey({
-			key,
-			value: value.unwrap(),
-			messages,
-			enums,
-			isOptional: true,
-			isInArray,
-			typePrefix,
-			useGoogleTimestamp,
-			hasTimestamp
-		})
+		return traverseKey(key, value.unwrap(), true, isInArray, context)
 	}
-
-	if (value instanceof ZodPipe) {
-		return traverseKey({
-			key,
-			value: value.in,
-			messages,
-			enums,
-			isOptional,
-			isInArray,
-			typePrefix,
-			useGoogleTimestamp,
-			hasTimestamp
-		})
-	}
-
-	if (value instanceof ZodDefault || value instanceof ZodCatch) {
-		return traverseKey({
-			key,
-			value: value.unwrap(),
-			messages,
-			enums,
-			isOptional,
-			isInArray,
-			typePrefix,
-			useGoogleTimestamp,
-			hasTimestamp
-		})
+	if (
+		value instanceof ZodPipe ||
+		value instanceof ZodDefault ||
+		value instanceof ZodCatch
+	) {
+		const inner = value instanceof ZodPipe ? value.in : value.unwrap()
+		return traverseKey(key, inner, isOptional, isInArray, context)
 	}
 
 	if (value instanceof ZodArray || value instanceof ZodSet) {
-		return traverseArray({
-			key,
-			value,
-			messages,
-			enums,
-			typePrefix,
-			useGoogleTimestamp,
-			hasTimestamp
-		})
+		return traverseArray(key, value, context)
 	}
 
 	if (value instanceof ZodMap) {
-		return traverseMap({
-			key,
-			value,
-			messages,
-			enums,
-			typePrefix,
-			useGoogleTimestamp,
-			hasTimestamp
-		})
-	}
-
-	if (value instanceof ZodRecord) {
-		const keyField = traverseKey({
-			key: `${key}Key`,
-			value: value.keyType,
-			messages,
-			enums,
-			isOptional: false,
-			isInArray: true,
-			typePrefix,
-			useGoogleTimestamp,
-			hasTimestamp
-		})
-		const valueField = traverseKey({
-			key: `${key}Value`,
-			value: value.valueType,
-			messages,
-			enums,
-			isOptional: false,
-			isInArray: true,
-			typePrefix,
-			useGoogleTimestamp,
-			hasTimestamp
-		})
-
-		if (!keyField[0] || keyField.length !== 1) {
-			throw new UnsupportedTypeException(`${key} record key`)
-		}
-		if (!valueField[0] || valueField.length !== 1) {
-			throw new UnsupportedTypeException(`${key} record value`)
-		}
-
-		const mapType = `map<${protobufFieldToType({ field: keyField[0] })}, ${protobufFieldToType({ field: valueField[0] })}>`
 		return [
-			{
-				types: [mapType],
-				name: key
-			}
+			toMapField(context, key, value.def.keyType, value.def.valueType, 'map')
 		]
 	}
 
+	if (value instanceof ZodRecord) {
+		return [toMapField(context, key, value.keyType, value.valueType, 'record')]
+	}
+
 	if (value instanceof ZodUnion || value instanceof ZodDiscriminatedUnion) {
-		const options = value.options
 		const members: ProtobufField[] = []
 		const usedSuffixes = new Set<string>()
 
-		for (const option of options) {
-			let suffix = getOneofTypeSuffix({ value: option })
+		for (const option of value.options) {
+			let suffix = getOneofTypeSuffix(option)
 			// Deduplicate suffixes
 			if (usedSuffixes.has(suffix)) {
 				let counter = 2
@@ -488,169 +333,75 @@ function traverseKey({
 			usedSuffixes.add(suffix)
 
 			const memberKey = `${key}_${suffix}`
-			const memberFields = traverseKey({
-				key: memberKey,
-				value: option,
-				messages,
-				enums,
-				isOptional: false,
-				isInArray: true,
-				typePrefix,
-				useGoogleTimestamp,
-				hasTimestamp
-			})
+			const memberFields = traverseKey(memberKey, option, false, true, context)
 			members.push(...memberFields)
 		}
 
-		return [
-			{
-				types: [],
-				name: key,
-				oneofMembers: members
-			}
-		]
+		return [{ types: [], name: key, oneofMembers: members }]
 	}
 
-	const optional = isOptional && !isInArray ? 'optional' : null
+	const optional = isOptional && !isInArray ? ['optional'] : []
 
 	if (value instanceof ZodObject) {
-		let messageName = toPascalCase({ value: key })
-		if (typePrefix) {
-			messageName = `${typePrefix}${messageName}`
-		}
-		const nestedMessageFields = traverseSchema({
-			schema: value,
-			messages,
-			enums,
-			typePrefix,
-			useGoogleTimestamp,
-			hasTimestamp
-		})
-		messages.set(messageName, nestedMessageFields)
-		return [
-			{
-				types: [optional, messageName],
-				name: key
-			}
-		]
+		const messageName = `${context.typePrefix}${toPascalCase(key)}`
+		context.messages.set(messageName, traverseSchema(value, context))
+		return [{ types: [...optional, messageName], name: key }]
 	}
 
 	if (value instanceof ZodString) {
-		return [
-			{
-				types: [optional, 'string'],
-				name: key
-			}
-		]
+		return [{ types: [...optional, 'string'], name: key }]
 	}
 
 	if (value instanceof ZodNumber) {
-		const typeName = getNumberTypeName({ value })
-		return [
-			{
-				types: [optional, typeName],
-				name: key
-			}
-		]
+		return [{ types: [...optional, getNumberTypeName(value)], name: key }]
 	}
 
 	if (value instanceof ZodBoolean) {
-		return [
-			{
-				types: [optional, 'bool'],
-				name: key
-			}
-		]
+		return [{ types: [...optional, 'bool'], name: key }]
 	}
 
 	if (value instanceof ZodEnum) {
-		let enumName = toPascalCase({ value: value.meta()?.id ?? key })
-		if (typePrefix) {
-			enumName = `${typePrefix}${enumName}`
-		}
-		const prefix = toScreamingSnakeCase({ value: enumName })
+		const baseName = toPascalCase(value.meta()?.id ?? key)
+		const enumName = `${context.typePrefix}${baseName}`
+		const prefix = toScreamingSnakeCase(enumName)
 		const unspecified = `    ${prefix}_UNSPECIFIED = 0;`
-		const enumFields = value.options
+		const enumMembers = value.options
 			.map(
 				(option, index) =>
 					`    ${prefix}_${String(option).toUpperCase()} = ${index + 1};`
 			)
 			.join('\n')
-		enums.set(enumName, [
-			`enum ${enumName} {\n${unspecified}\n${enumFields}\n}`
+		context.enums.set(enumName, [
+			`enum ${enumName} {\n${unspecified}\n${enumMembers}\n}`
 		])
-		return [
-			{
-				types: [optional, enumName],
-				name: key
-			}
-		]
+		return [{ types: [...optional, enumName], name: key }]
 	}
 
 	if (value instanceof ZodLiteral) {
-		return [
-			{
-				types: [optional, getLiteralTypeName({ value })],
-				name: key
-			}
-		]
+		return [{ types: [...optional, getLiteralTypeName(value)], name: key }]
 	}
 
 	if (value instanceof ZodDate) {
-		if (useGoogleTimestamp) {
-			hasTimestamp.value = true
-			return [
-				{
-					types: [optional, 'google.protobuf.Timestamp'],
-					name: key
-				}
-			]
+		if (context.useGoogleTimestamp) {
+			context.hasTimestamp = true
+			return [{ types: [...optional, 'google.protobuf.Timestamp'], name: key }]
 		}
-		return [
-			{
-				types: [optional, 'string'],
-				name: key
-			}
-		]
+		return [{ types: [...optional, 'string'], name: key }]
 	}
 
 	if (value instanceof ZodBigInt) {
-		return [
-			{
-				types: [optional, 'int64'],
-				name: key
-			}
-		]
+		return [{ types: [...optional, 'int64'], name: key }]
 	}
 
 	if (value instanceof ZodTuple) {
 		const tupleFields: ProtobufField[] = value.def.items.flatMap(
-			(item, index) => {
-				return traverseKey({
-					key: `${key}_${index}`,
-					value: item,
-					messages,
-					enums,
-					isOptional: false,
-					isInArray,
-					typePrefix,
-					useGoogleTimestamp,
-					hasTimestamp
-				})
-			}
+			(item, index) =>
+				traverseKey(`${key}_${index}`, item, false, isInArray, context)
 		)
 
-		let tupleMessageName = toPascalCase({ value: key })
-		if (typePrefix) {
-			tupleMessageName = `${typePrefix}${tupleMessageName}`
-		}
-		messages.set(tupleMessageName, formatFields({ fields: tupleFields }))
-		return [
-			{
-				types: [optional, tupleMessageName],
-				name: key
-			}
-		]
+		const tupleMessageName = `${context.typePrefix}${toPascalCase(key)}`
+		context.messages.set(tupleMessageName, formatFields(tupleFields))
+		return [{ types: [...optional, tupleMessageName], name: key }]
 	}
 
 	throw new UnsupportedTypeException(value.constructor.name)
@@ -659,47 +410,19 @@ function traverseKey({
 /**
  * Traverses a schema and generates Protobuf fields.
  * @param schema The Zod schema.
- * @param messages The map of message definitions.
- * @param enums The map of enum definitions.
- * @param typePrefix The prefix for type names.
- * @param useGoogleTimestamp Whether to use google.protobuf.Timestamp for dates.
- * @param hasTimestamp Mutable ref tracking if Timestamp import is needed.
+ * @param context Shared traversal state.
  * @returns An array of formatted Protobuf field strings.
  */
-function traverseSchema({
-	schema,
-	messages,
-	enums,
-	typePrefix,
-	useGoogleTimestamp,
-	hasTimestamp
-}: {
-	schema: $ZodType
-	messages: Map<string, string[]>
-	enums: Map<string, string[]>
-	typePrefix: string | null
-	useGoogleTimestamp: boolean
-	hasTimestamp: { value: boolean }
-}): string[] {
+function traverseSchema(schema: $ZodType, context: Context): string[] {
 	if (!(schema instanceof ZodObject)) {
 		throw new UnsupportedTypeException(schema.constructor.name)
 	}
 
-	const fields = Object.entries(schema.shape).flatMap(([key, value]) => {
-		return traverseKey({
-			key,
-			value,
-			messages,
-			enums,
-			isOptional: false,
-			isInArray: false,
-			typePrefix,
-			useGoogleTimestamp,
-			hasTimestamp
-		})
-	})
+	const fields = Object.entries(schema.shape).flatMap(([key, value]) =>
+		traverseKey(key, value, false, false, context)
+	)
 
-	return formatFields({ fields })
+	return formatFields(fields)
 }
 
 /**
@@ -719,32 +442,33 @@ function zodToProtobuf(
 		useGoogleTimestamp = false
 	} = options
 
-	const messages = new Map<string, string[]>()
-	const enums = new Map<string, string[]>()
-	const hasTimestamp = { value: false }
-
-	const rootFields = traverseSchema({
-		schema,
-		messages,
-		enums,
+	const context: Context = {
+		messages: new Map<string, string[]>(),
+		enums: new Map<string, string[]>(),
 		typePrefix,
 		useGoogleTimestamp,
-		hasTimestamp
-	})
-	messages.set(`${typePrefix}${rootMessageName}`, rootFields)
+		hasTimestamp: false
+	}
+
+	context.messages.set(
+		typePrefix + rootMessageName,
+		traverseSchema(schema, context)
+	)
 
 	// Validate no enum/message name collisions
-	for (const enumName of enums.keys()) {
-		if (messages.has(enumName)) {
+	for (const enumName of context.enums.keys()) {
+		if (context.messages.has(enumName)) {
 			throw new Error(
 				`Name collision: "${enumName}" is used for both an enum and a message. Use .meta({ id: '...' }) on the enum to give it a unique name.`
 			)
 		}
 	}
 
-	const enumsString = [...enums.values()].map((enumDef) => enumDef.join('\n'))
+	const enumsString = [...context.enums.values()].map((enumDef) =>
+		enumDef.join('\n')
+	)
 
-	const messagesString = [...messages.entries()].map(
+	const messagesString = [...context.messages.entries()].map(
 		([name, fieldLines]) =>
 			`message ${name} {\n${fieldLines.map((field) => `    ${field}`).join('\n')}\n}`
 	)
@@ -754,7 +478,7 @@ function zodToProtobuf(
 		.map((strings) => strings.join('\n\n'))
 		.join('\n\n')
 
-	const imports = hasTimestamp.value
+	const imports = context.hasTimestamp
 		? '\nimport "google/protobuf/timestamp.proto";\n'
 		: ''
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,12 +19,15 @@ import {
 	ZodSet,
 	ZodString,
 	ZodTuple,
-	ZodType,
 	ZodUnion,
 	type ZodTypeAny
 } from 'zod'
+// SAFETY note on the umbrella type below: $ZodType is zod v4's structural
+// schema interface, so every runtime `instanceof ZodXxx` narrowing is
+// assignable to it without assertions -- unlike the nominal ZodTypeAny class.
+import { type $ZodType } from 'zod/v4/core'
 
-interface ZodToProtobufOptions {
+type ZodToProtobufOptions = {
 	packageName?: string
 	rootMessageName?: string
 	typePrefix?: string
@@ -38,7 +41,7 @@ class UnsupportedTypeException extends Error {
 	}
 }
 
-interface ProtobufField {
+type ProtobufField = {
 	types: Array<string | null>
 	name: string
 	oneofMembers?: ProtobufField[]
@@ -49,7 +52,7 @@ interface ProtobufField {
  * @param value The ZodNumber instance.
  * @returns The Protobuf type name.
  */
-const getNumberTypeName = ({ value }: { value: ZodNumber }): string => {
+function getNumberTypeName({ value }: { value: ZodNumber }): string {
 	return value.isInt ? 'int32' : 'double'
 }
 
@@ -58,7 +61,7 @@ const getNumberTypeName = ({ value }: { value: ZodNumber }): string => {
  * @param value The string.
  * @returns The PascalCase string.
  */
-const toPascalCase = ({ value }: { value: string }): string => {
+function toPascalCase({ value }: { value: string }): string {
 	return value
 		.split('.')
 		.map((part) => part.charAt(0).toUpperCase() + part.slice(1))
@@ -70,14 +73,14 @@ const toPascalCase = ({ value }: { value: string }): string => {
  * @param value The string.
  * @returns The SCREAMING_SNAKE_CASE string.
  */
-const toScreamingSnakeCase = ({ value }: { value: string }): string => {
+function toScreamingSnakeCase({ value }: { value: string }): string {
 	return value
-		.replace(/([a-z0-9])([A-Z])/g, '$1_$2')
-		.replace(/([A-Z])([A-Z][a-z])/g, '$1_$2')
+		.replaceAll(/([a-z0-9])([A-Z])/g, '$1_$2')
+		.replaceAll(/([A-Z])([A-Z][a-z])/g, '$1_$2')
 		.toUpperCase()
 }
 
-const protobufFieldToType = ({ field }: { field: ProtobufField }) => {
+function protobufFieldToType({ field }: { field: ProtobufField }) {
 	return field.types.filter(Boolean).join(' ')
 }
 
@@ -87,7 +90,7 @@ const protobufFieldToType = ({ field }: { field: ProtobufField }) => {
  * @param fields The ProtobufField array.
  * @returns An array of formatted field strings.
  */
-const formatFields = ({ fields }: { fields: ProtobufField[] }): string[] => {
+function formatFields({ fields }: { fields: ProtobufField[] }): string[] {
 	const lines: string[] = []
 	let fieldNum = 1
 	for (const field of fields) {
@@ -115,11 +118,9 @@ const formatFields = ({ fields }: { fields: ProtobufField[] }): string[] => {
  * @param value The Zod schema value.
  * @returns A short string suffix.
  */
-const getOneofTypeSuffix = ({ value }: { value: unknown }): string => {
+function getOneofTypeSuffix({ value }: { value: unknown }): string {
 	if (value instanceof ZodString) return 'string'
-	if (value instanceof ZodNumber) {
-		return (value as ZodNumber).isInt ? 'int32' : 'double'
-	}
+	if (value instanceof ZodNumber) return value.isInt ? 'int32' : 'double'
 	if (value instanceof ZodBoolean) return 'bool'
 	if (value instanceof ZodBigInt) return 'int64'
 	if (value instanceof ZodDate) return 'date'
@@ -128,6 +129,49 @@ const getOneofTypeSuffix = ({ value }: { value: unknown }): string => {
 	if (value instanceof ZodEnum) return 'enum'
 	if (value instanceof ZodLiteral) return 'literal'
 	return 'value'
+}
+
+/**
+ * Maps a ZodLiteral to its Protobuf scalar type by inspecting the JS runtime
+ * type of the literal's held values.
+ * @param value The ZodLiteral instance.
+ * @returns The Protobuf scalar type name.
+ */
+function getLiteralTypeName({ value }: { value: ZodLiteral }): string {
+	/* oxlint-disable anti-slop/no-runtime-typeof --
+	 * Discriminating a ZodLiteral by the JavaScript primitive type of its
+	 * held values IS this library's domain logic, not smuggled slop. proto3's
+	 * int32/double/string/bool split follows the runtime primitive type, and
+	 * zod exposes no static marker distinguishing z.literal("x") from
+	 * z.literal(1). This function is the I/O boundary; there is nothing
+	 * earlier to parse against.
+	 */
+	const first = value.values.values().next().value
+	if (typeof first === 'string') return 'string'
+	if (typeof first === 'number') {
+		return Number.isInteger(first) ? 'int32' : 'double'
+	}
+	if (typeof first === 'boolean') return 'bool'
+	throw new UnsupportedTypeException(`ZodLiteral(${typeof first})`)
+	/* oxlint-enable anti-slop/no-runtime-typeof */
+}
+
+/**
+ * Wraps already-generated fields as repeated members under an outer key,
+ * used when flattening nested array/set element types.
+ * @param field The generated element field.
+ * @param key The outer (plural) key.
+ * @returns The repeated field definition.
+ */
+function toRepeatedField(field: ProtobufField, key: string): ProtobufField {
+	const repeatedField: ProtobufField = {
+		types: ['repeated', ...field.types],
+		name: key
+	}
+	if (field.oneofMembers) {
+		repeatedField.oneofMembers = field.oneofMembers
+	}
+	return repeatedField
 }
 
 /**
@@ -142,7 +186,7 @@ const getOneofTypeSuffix = ({ value }: { value: unknown }): string => {
  * @param hasTimestamp Mutable ref tracking if Timestamp import is needed.
  * @returns An array of Protobuf field definitions.
  */
-const traverseArray = ({
+function traverseArray({
 	key,
 	value,
 	messages,
@@ -152,22 +196,20 @@ const traverseArray = ({
 	hasTimestamp
 }: {
 	key: string
-	value: ZodArray<ZodTypeAny> | ZodSet<ZodTypeAny>
+	value: ZodArray | ZodSet
 	messages: Map<string, string[]>
 	enums: Map<string, string[]>
 	typePrefix: string | null
 	useGoogleTimestamp: boolean
 	hasTimestamp: { value: boolean }
-}): ProtobufField[] => {
+}): ProtobufField[] {
 	const nestedValue =
-		value instanceof ZodArray
-			? value.element
-			: (value as ZodSet<ZodTypeAny>).def.valueType
+		value instanceof ZodArray ? value.element : value.def.valueType
 
 	// Unwrap optional/nullable to check the underlying type
 	let unwrapped: unknown = nestedValue
 	while (unwrapped instanceof ZodOptional || unwrapped instanceof ZodNullable) {
-		unwrapped = (unwrapped as ZodOptional<ZodTypeAny>).unwrap()
+		unwrapped = unwrapped.unwrap()
 	}
 
 	// Nested array/set: wrap inner array in a message to avoid invalid `repeated repeated`
@@ -187,7 +229,7 @@ const traverseArray = ({
 
 		const innerFields = traverseArray({
 			key: singularKey,
-			value: unwrapped as ZodArray<ZodTypeAny> | ZodSet<ZodTypeAny>,
+			value: unwrapped,
 			messages,
 			enums,
 			typePrefix,
@@ -217,11 +259,7 @@ const traverseArray = ({
 		useGoogleTimestamp,
 		hasTimestamp
 	})
-	return elementFields.map((field) => ({
-		...field,
-		types: ['repeated', ...field.types],
-		name: key
-	}))
+	return elementFields.map((field) => toRepeatedField(field, key))
 }
 
 /**
@@ -235,7 +273,7 @@ const traverseArray = ({
  * @param hasTimestamp Mutable ref tracking if Timestamp import is needed.
  * @returns An array of Protobuf field definitions.
  */
-const traverseMap = ({
+function traverseMap({
 	key,
 	value,
 	messages,
@@ -245,13 +283,13 @@ const traverseMap = ({
 	hasTimestamp
 }: {
 	key: string
-	value: ZodMap<ZodTypeAny, ZodTypeAny>
+	value: ZodMap
 	messages: Map<string, string[]>
 	enums: Map<string, string[]>
 	typePrefix: string | null
 	useGoogleTimestamp: boolean
 	hasTimestamp: { value: boolean }
-}): ProtobufField[] => {
+}): ProtobufField[] {
 	const keyType = traverseKey({
 		key: `${key}Key`,
 		value: value.def.keyType,
@@ -305,7 +343,7 @@ const traverseMap = ({
  * @param hasTimestamp Mutable ref tracking if Timestamp import is needed.
  * @returns An array of Protobuf field definitions.
  */
-const traverseKey = ({
+function traverseKey({
 	key,
 	value,
 	messages,
@@ -317,7 +355,7 @@ const traverseKey = ({
 	hasTimestamp
 }: {
 	key: string
-	value: unknown
+	value: $ZodType
 	messages: Map<string, string[]>
 	enums: Map<string, string[]>
 	isOptional: boolean
@@ -325,11 +363,11 @@ const traverseKey = ({
 	typePrefix: string | null
 	useGoogleTimestamp: boolean
 	hasTimestamp: { value: boolean }
-}): ProtobufField[] => {
+}): ProtobufField[] {
 	if (value instanceof ZodOptional || value instanceof ZodNullable) {
 		return traverseKey({
 			key,
-			value: (value as ZodOptional<ZodTypeAny>).unwrap(),
+			value: value.unwrap(),
 			messages,
 			enums,
 			isOptional: true,
@@ -343,7 +381,7 @@ const traverseKey = ({
 	if (value instanceof ZodPipe) {
 		return traverseKey({
 			key,
-			value: (value as ZodPipe<ZodTypeAny, ZodTypeAny>).in,
+			value: value.in,
 			messages,
 			enums,
 			isOptional,
@@ -357,7 +395,7 @@ const traverseKey = ({
 	if (value instanceof ZodDefault || value instanceof ZodCatch) {
 		return traverseKey({
 			key,
-			value: (value as ZodDefault<ZodTypeAny> | ZodCatch<ZodTypeAny>).unwrap(),
+			value: value.unwrap(),
 			messages,
 			enums,
 			isOptional,
@@ -371,7 +409,7 @@ const traverseKey = ({
 	if (value instanceof ZodArray || value instanceof ZodSet) {
 		return traverseArray({
 			key,
-			value: value as ZodArray<ZodTypeAny> | ZodSet<ZodTypeAny>,
+			value,
 			messages,
 			enums,
 			typePrefix,
@@ -383,7 +421,7 @@ const traverseKey = ({
 	if (value instanceof ZodMap) {
 		return traverseMap({
 			key,
-			value: value as ZodMap<ZodTypeAny, ZodTypeAny>,
+			value,
 			messages,
 			enums,
 			typePrefix,
@@ -393,10 +431,9 @@ const traverseKey = ({
 	}
 
 	if (value instanceof ZodRecord) {
-		const recordValue = value as ZodRecord
-		const keyType = traverseKey({
+		const keyField = traverseKey({
 			key: `${key}Key`,
-			value: recordValue.keyType,
+			value: value.keyType,
 			messages,
 			enums,
 			isOptional: false,
@@ -405,9 +442,9 @@ const traverseKey = ({
 			useGoogleTimestamp,
 			hasTimestamp
 		})
-		const valueType = traverseKey({
+		const valueField = traverseKey({
 			key: `${key}Value`,
-			value: recordValue.valueType,
+			value: value.valueType,
 			messages,
 			enums,
 			isOptional: false,
@@ -417,14 +454,14 @@ const traverseKey = ({
 			hasTimestamp
 		})
 
-		if (!keyType[0] || keyType.length !== 1) {
+		if (!keyField[0] || keyField.length !== 1) {
 			throw new UnsupportedTypeException(`${key} record key`)
 		}
-		if (!valueType[0] || valueType.length !== 1) {
+		if (!valueField[0] || valueField.length !== 1) {
 			throw new UnsupportedTypeException(`${key} record value`)
 		}
 
-		const mapType = `map<${protobufFieldToType({ field: keyType[0] })}, ${protobufFieldToType({ field: valueType[0] })}>`
+		const mapType = `map<${protobufFieldToType({ field: keyField[0] })}, ${protobufFieldToType({ field: valueField[0] })}>`
 		return [
 			{
 				types: [mapType],
@@ -434,8 +471,7 @@ const traverseKey = ({
 	}
 
 	if (value instanceof ZodUnion || value instanceof ZodDiscriminatedUnion) {
-		const options = (value as ZodUnion<[ZodTypeAny, ...ZodTypeAny[]]>)
-			.options as ZodTypeAny[]
+		const options = value.options
 		const members: ProtobufField[] = []
 		const usedSuffixes = new Set<string>()
 
@@ -534,9 +570,9 @@ const traverseKey = ({
 		}
 		const prefix = toScreamingSnakeCase({ value: enumName })
 		const unspecified = `    ${prefix}_UNSPECIFIED = 0;`
-		const enumFields = (value.options as Array<string | number>)
+		const enumFields = value.options
 			.map(
-				(option: string | number, index: number) =>
+				(option, index) =>
 					`    ${prefix}_${String(option).toUpperCase()} = ${index + 1};`
 			)
 			.join('\n')
@@ -552,23 +588,12 @@ const traverseKey = ({
 	}
 
 	if (value instanceof ZodLiteral) {
-		const literalValues = (value as ZodLiteral).values
-		const first = literalValues.values().next().value
-		if (typeof first === 'string') {
-			return [{ types: [optional, 'string'], name: key }]
-		}
-		if (typeof first === 'number') {
-			return [
-				{
-					types: [optional, Number.isInteger(first) ? 'int32' : 'double'],
-					name: key
-				}
-			]
-		}
-		if (typeof first === 'boolean') {
-			return [{ types: [optional, 'bool'], name: key }]
-		}
-		throw new UnsupportedTypeException(`ZodLiteral(${typeof first})`)
+		return [
+			{
+				types: [optional, getLiteralTypeName({ value })],
+				name: key
+			}
+		]
 	}
 
 	if (value instanceof ZodDate) {
@@ -599,22 +624,21 @@ const traverseKey = ({
 	}
 
 	if (value instanceof ZodTuple) {
-		const tupleFields: ProtobufField[] = (
-			(value as ZodTuple<[ZodTypeAny, ...ZodTypeAny[]]>).def
-				.items as ZodTypeAny[]
-		).flatMap((item: ZodTypeAny, index: number) => {
-			return traverseKey({
-				key: `${key}_${index}`,
-				value: item,
-				messages,
-				enums,
-				isOptional: false,
-				isInArray,
-				typePrefix,
-				useGoogleTimestamp,
-				hasTimestamp
-			})
-		})
+		const tupleFields: ProtobufField[] = value.def.items.flatMap(
+			(item, index) => {
+				return traverseKey({
+					key: `${key}_${index}`,
+					value: item,
+					messages,
+					enums,
+					isOptional: false,
+					isInArray,
+					typePrefix,
+					useGoogleTimestamp,
+					hasTimestamp
+				})
+			}
+		)
 
 		let tupleMessageName = toPascalCase({ value: key })
 		if (typePrefix) {
@@ -629,11 +653,7 @@ const traverseKey = ({
 		]
 	}
 
-	if (value instanceof ZodType) {
-		throw new UnsupportedTypeException(value.constructor.name)
-	}
-
-	throw new UnsupportedTypeException(typeof value)
+	throw new UnsupportedTypeException(value.constructor.name)
 }
 
 /**
@@ -646,7 +666,7 @@ const traverseKey = ({
  * @param hasTimestamp Mutable ref tracking if Timestamp import is needed.
  * @returns An array of formatted Protobuf field strings.
  */
-const traverseSchema = ({
+function traverseSchema({
 	schema,
 	messages,
 	enums,
@@ -654,13 +674,13 @@ const traverseSchema = ({
 	useGoogleTimestamp,
 	hasTimestamp
 }: {
-	schema: ZodTypeAny
+	schema: $ZodType
 	messages: Map<string, string[]>
 	enums: Map<string, string[]>
 	typePrefix: string | null
 	useGoogleTimestamp: boolean
 	hasTimestamp: { value: boolean }
-}): string[] => {
+}): string[] {
 	if (!(schema instanceof ZodObject)) {
 		throw new UnsupportedTypeException(schema.constructor.name)
 	}
@@ -688,10 +708,10 @@ const traverseSchema = ({
  * @param options The conversion options.
  * @returns The Protobuf definition.
  */
-const zodToProtobuf = (
+function zodToProtobuf(
 	schema: ZodTypeAny,
 	options: ZodToProtobufOptions = {}
-): string => {
+): string {
 	const {
 		packageName = 'default',
 		rootMessageName = 'Message',
@@ -703,7 +723,7 @@ const zodToProtobuf = (
 	const enums = new Map<string, string[]>()
 	const hasTimestamp = { value: false }
 
-	const fields = traverseSchema({
+	const rootFields = traverseSchema({
 		schema,
 		messages,
 		enums,
@@ -711,7 +731,7 @@ const zodToProtobuf = (
 		useGoogleTimestamp,
 		hasTimestamp
 	})
-	messages.set(`${typePrefix}${rootMessageName}`, fields)
+	messages.set(`${typePrefix}${rootMessageName}`, rootFields)
 
 	// Validate no enum/message name collisions
 	for (const enumName of enums.keys()) {
@@ -722,13 +742,11 @@ const zodToProtobuf = (
 		}
 	}
 
-	const enumsString = Array.from(enums.values()).map((enumDef) =>
-		enumDef.join('\n')
-	)
+	const enumsString = [...enums.values()].map((enumDef) => enumDef.join('\n'))
 
-	const messagesString = Array.from(messages.entries()).map(
-		([name, fields]) =>
-			`message ${name} {\n${fields.map((field) => `    ${field}`).join('\n')}\n}`
+	const messagesString = [...messages.entries()].map(
+		([name, fieldLines]) =>
+			`message ${name} {\n${fieldLines.map((field) => `    ${field}`).join('\n')}\n}`
 	)
 
 	const content = [enumsString, messagesString]

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -284,14 +284,14 @@ message Message {
 	})
 
 	it('should throw exception on unsupported Object type', () => {
-		// @ts-expect-error
+		// @ts-expect-error -- exercising the runtime guard with a non-schema value
 		expect(() => zodToProtobuf({ test: 1 })).toThrowError(
 			'Unsupported type: Object'
 		)
 	})
 
 	it('should throw exception on unsupported Number type', () => {
-		// @ts-expect-error
+		// @ts-expect-error -- exercising the runtime guard with a non-schema value
 		expect(() => zodToProtobuf(1)).toThrowError('Unsupported type: Number')
 	})
 


### PR DESCRIPTION
## Summary

- Rewrites `.oxlintrc.json` into a strict, repo-appropriate config: correctness + suspicious + perf categories at `error`, the strong unicorn/oxc/import/promise rule sets from the b2b-saas-starter reference (DOM/browser rules skipped), plus type-aware heavies (`no-unsafe-type-assertion`, `no-unnecessary-condition`, `unbound-method`, `no-base-to-string`, `restrict-plus-operands`, `switch-exhaustiveness-check`, ...). `reportUnusedDisableDirectives: "deny"` keeps suppressions honest.
- Enables the ultracite anti-slop plugin (pinned 7.10.6 devDependency). All 15 anti-slop rules are enabled except one (see below).
- Hardens `src/index.ts` with real refactorings (57 lint findings fixed without blanket downgrades):
  - **Typed traversal instead of casts**: internals now thread zod v4's structural `$ZodType` interface instead of `unknown`. Since every `instanceof ZodXxx` narrowing is assignable to `$ZodType`, all unsafe/unnecessary type assertions were deleted outright - zero assertions remain in the library.
  - **Arrow-function consts become function declarations** across all helpers, letting the mutually recursive traversers read naturally.
  - `traverseArray` no longer spreads objects inside `.map` (oxc/no-map-spread) - explicit field construction via a new `toRepeatedField` helper.
  - `replace(//g)` becomes `replaceAll`, `Array.from` becomes spread, shadowed `fields` renamed.
  - The runtime-`typeof` literal discriminator moved into `getLiteralTypeName` behind a single scoped, commented `oxlint-disable` region: discriminating a `ZodLiteral` by JS primitive type IS the domain logic (proto3's int32/double/string/bool split), and zod exposes no static marker for it.
  - Dropped the now-dead non-schema fallback branches in `traverseKey`; unsupported schemas are reported via `constructor.name` on a single throw (public API unchanged; exception messages preserved and covered by tests).
- Tests: added required explanations to two bare `@ts-expect-error` directives.

## Anti-slop rules left off

- `anti-slop/no-shape-in-symbol-names` - flags any identifier containing "shape", including plain member access. This library reads zod's official `schema.shape` accessor for object fields, so the rule would require an inline disable at every `.shape` read forever. Off with an explanatory comment in config.

## Test plan

- [x] `npx oxlint --type-aware`: zero errors/warnings
- [x] `npm test`: 45 pass, 0 fail
- [x] `npm run build` (tsc): clean
- [x] oxfmt clean
