### PR TITLE
docs: sync README with recent changes and trim

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,18 +7,14 @@ Convert Zod 4 schemas to Protocol Buffers (proto3) definitions.
 
 ## Features
 
-- Primitives: `string`, `number`, `boolean`, `date`, `bigint`, `literal`
-- Integers: `z.number().int()` maps to `int32` (otherwise `double`)
-- Collections: `array`, `set`, `map`, `record`, `tuple`
-- Nested objects with automatic message generation
-- Unions: `z.union()` and `z.discriminatedUnion()` map to `oneof`
-- Enums with `UNSPECIFIED` zero value and prefixed names per proto3 style guide
-- Custom enum naming via `.meta({ id: 'Name' })`
-- Optional and nullable fields
-- Wrappers: `ZodPipe`, `ZodDefault`, `ZodCatch` (unwrapped automatically)
-- Nested arrays wrapped in messages (valid proto3, no `repeated repeated`)
-- Configurable package name, root message name, and type prefix
-- Optional `google.protobuf.Timestamp` for date fields
+- Primitives map to proto3 scalars: `z.number().int()` → `int32`, `z.number()` → `double`, `z.bigint()` → `int64`, `z.date()` → `string`
+- Collections: array/set → `repeated`, map/record → `map<K, V>`, tuple → nested message
+- Nested objects generate messages automatically
+- `z.union()` and `z.discriminatedUnion()` → `oneof`
+- Enums get a zero `UNSPECIFIED` value and prefixed names per proto3 style; override the name with `.meta({ id: 'Name' })` (also resolves enum/message name collisions)
+- `.optional()` / `.nullable()` → `optional`; `ZodPipe`, `ZodDefault`, `ZodCatch` are unwrapped
+- Nested arrays wrap in messages instead of emitting invalid `repeated repeated`
+- Options: `packageName`, `rootMessageName`, `typePrefix`, and `useGoogleTimestamp` to emit `google.protobuf.Timestamp` for dates
 
 ## Installation
 
@@ -26,11 +22,9 @@ Convert Zod 4 schemas to Protocol Buffers (proto3) definitions.
 npm install zod-to-protobuf
 ```
 
-**Requirements:** Node.js >= 20, Zod 4
+Requires Zod 4 as a peer dependency.
 
 ## Usage
-
-### Basic
 
 ```typescript
 import { z } from 'zod'
@@ -54,27 +48,28 @@ message Message {
 }
 ```
 
-### Nested objects, enums, and arrays
+A richer example with enums, nesting, unions, and the Timestamp option:
 
 ```typescript
 const schema = z.object({
 	id: z.number().int(),
-	name: z.string(),
 	isActive: z.boolean(),
 	roles: z.array(z.enum(['ADMIN', 'USER', 'GUEST'])),
-	address: z.object({
-		street: z.string(),
-		city: z.string(),
-		postalCode: z.string()
-	})
+	address: z.object({ street: z.string(), city: z.string() }),
+	value: z.union([z.string(), z.number().int()]),
+	createdAt: z.date()
 })
 
-console.log(zodToProtobuf(schema, { rootMessageName: 'User' }))
+console.log(
+	zodToProtobuf(schema, { rootMessageName: 'User', useGoogleTimestamp: true })
+)
 ```
 
 ```protobuf
 syntax = "proto3";
 package default;
+
+import "google/protobuf/timestamp.proto";
 
 enum Role {
     ROLE_UNSPECIFIED = 0;
@@ -86,140 +81,40 @@ enum Role {
 message Address {
     string street = 1;
     string city = 2;
-    string postalCode = 3;
 }
 
 message User {
     int32 id = 1;
-    string name = 2;
-    bool isActive = 3;
-    repeated Role roles = 4;
-    Address address = 5;
-}
-```
-
-### Optional and nullable fields
-
-```typescript
-const schema = z.object({
-	name: z.string(),
-	nickname: z.string().optional(),
-	bio: z.string().nullable()
-})
-```
-
-```protobuf
-message Message {
-    string name = 1;
-    optional string nickname = 2;
-    optional string bio = 3;
-}
-```
-
-### Unions (oneof)
-
-```typescript
-const schema = z.object({
-	value: z.union([z.string(), z.number().int()])
-})
-```
-
-```protobuf
-message Message {
+    bool isActive = 2;
+    repeated Role roles = 3;
+    Address address = 4;
     oneof value {
-        string value_string = 1;
-        int32 value_int32 = 2;
+        string value_string = 5;
+        int32 value_int32 = 6;
     }
+    google.protobuf.Timestamp createdAt = 7;
 }
 ```
-
-### Maps and records
-
-```typescript
-const schema = z.object({
-	metadata: z.map(z.string(), z.number().int()),
-	settings: z.record(z.string(), z.string())
-})
-```
-
-```protobuf
-message Message {
-    map<string, int32> metadata = 1;
-    map<string, string> settings = 2;
-}
-```
-
-### Google Timestamp
-
-```typescript
-const schema = z.object({
-	createdAt: z.date(),
-	updatedAt: z.date()
-})
-
-console.log(zodToProtobuf(schema, { useGoogleTimestamp: true }))
-```
-
-```protobuf
-syntax = "proto3";
-package default;
-
-import "google/protobuf/timestamp.proto";
-
-message Message {
-    google.protobuf.Timestamp createdAt = 1;
-    google.protobuf.Timestamp updatedAt = 2;
-}
-```
-
-## Type Mapping
-
-| Zod Type                              | Protobuf Type               |
-| ------------------------------------- | --------------------------- |
-| `z.string()`                          | `string`                    |
-| `z.number()`                          | `double`                    |
-| `z.number().int()`                    | `int32`                     |
-| `z.boolean()`                         | `bool`                      |
-| `z.bigint()`                          | `int64`                     |
-| `z.date()`                            | `string`                    |
-| `z.date()` + `useGoogleTimestamp`     | `google.protobuf.Timestamp` |
-| `z.literal("...")`                    | `string`                    |
-| `z.literal(123)`                      | `int32` or `double`         |
-| `z.literal(true)`                     | `bool`                      |
-| `z.array()`                           | `repeated`                  |
-| `z.set()`                             | `repeated`                  |
-| `z.map()`                             | `map<K, V>`                 |
-| `z.record()`                          | `map<K, V>`                 |
-| `z.object()`                          | `message`                   |
-| `z.enum()`                            | `enum` (with `UNSPECIFIED`) |
-| `z.tuple()`                           | `message`                   |
-| `z.union()`                           | `oneof`                     |
-| `z.discriminatedUnion()`              | `oneof`                     |
-| `.optional()`                         | `optional`                  |
-| `.nullable()`                         | `optional`                  |
-| `.default()` / `.catch()` / `.pipe()` | unwrapped                   |
-
-## Options
-
-| Option               | Description                                    | Default   |
-| -------------------- | ---------------------------------------------- | --------- |
-| `packageName`        | Name of the protobuf package                   | `default` |
-| `rootMessageName`    | Name of the root message                       | `Message` |
-| `typePrefix`         | Prefix for generated types                     | `""`      |
-| `useGoogleTimestamp` | Use `google.protobuf.Timestamp` for `z.date()` | `false`   |
 
 ## Contributing
 
 Contributions are welcome! Please open an issue or submit a pull request.
 
-### Development
-
 ```bash
 git clone https://github.com/brandhaug/zod-to-protobuf.git
 cd zod-to-protobuf
-npm install
-npm test
+bun install
 ```
+
+| Command            | Description                                       |
+| ------------------ | ------------------------------------------------- |
+| `npm test`         | Run tests (`bun test`)                            |
+| `npm run build`    | Compile TypeScript to `dist/`                     |
+| `npm run lint`     | Type-aware oxlint (strict config incl. anti-slop) |
+| `npm run format`   | Format with oxfmt                                 |
+| `npm run validate` | Lint + tests (CI)                                 |
+
+Formatting is enforced by a git pre-commit hook (installed on `bun install`), not in CI. Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) and PR titles are gated on it.
 
 ## License
 


### PR DESCRIPTION
## Summary
- Trim README from 226 to ~120 lines: badges, one-line description, compact features, install, two verified usage examples, dev commands, license
- Update contributor docs for last week's toolchain changes: tests run with `bun test`, formatting enforced via pre-commit hook (not CI), strict oxlint incl. anti-slop rules, conventional-commit PR title gate
- Document the new enum/message name collision guidance (`.meta({ id })`) introduced by the #24 hardening refactor
- Merge 8 scattered examples into a basic + one richer example; all protobuf output blocks verified against actual `zodToProtobuf()` output

## Validation
- `npm run validate` passes (lint + 45 bun tests)
- Every example executed against src and diffed character-for-character