### PR TITLE
docs: sync AGENTS.md with recent changes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,20 +4,15 @@
 
 **zod-to-protobuf** converts Zod 4 schemas to Protocol Buffer (proto3) definitions. Single-package TypeScript library published to npm.
 
-- **Source:** `src/index.ts` (single file, ~750 lines)
-- **Tests:** `test/index.test.ts` (~1000 lines, 50+ test cases)
-- **Build output:** `dist/`
-- **Module system:** ESM with CommonJS module resolution (node16)
+- **Source:** `src/index.ts` (single file) · **Tests:** `test/index.test.ts` · **Build output:** `dist/`
 
 ## Setup
 
 ```sh
-npm install
+bun install
 ```
 
-No lockfile is generated (`.npmrc` has `package-lock=false`). Dependencies are pinned to exact versions (`save-exact=true`).
-
-**Node.js >= 20 required.**
+**Bun >= 1.4 required** (`engines`, CI pins 1.4.0). Dependency versions are pinned via the `catalog` block in `package.json`; dep bumps flow through the catalog-update automation.
 
 ## Development Commands
 
@@ -26,28 +21,26 @@ No lockfile is generated (`.npmrc` has `package-lock=false`). Dependencies are p
 | `npm run build`    | Compile TypeScript to `dist/`     |
 | `npm run lint`     | Run oxlint with type-aware checks |
 | `npm run format`   | Format with oxfmt (write mode)    |
-| `npm test`         | Run Vitest in watch mode          |
-| `npm run validate` | Lint + tests (CI)                 |
+| `npm test`         | Run Bun tests                     |
+| `npm run validate` | Lint + tests                      |
 
 ## Testing
 
-- **Framework:** Vitest
-- **Run all tests:** `npm test`
-- **Run once (no watch):** `npx vitest run`
-- **Run a specific test:** `npx vitest run -t "test name"`
-- **Test file:** `test/index.test.ts`
-- Tests compare generated protobuf output strings against expected values. Always verify the full protobuf output matches expectations.
+Tests run with **Bun's built-in runner** (`bun test`); filter with `bun test -t "test name"`.
+
+Tests compare generated protobuf output strings against expected values. Always verify the full protobuf output matches expectations.
+
+## Code Standards
+
+- Strict oxlint with anti-slop rules (ultracite plugin): `src/` must stay lint-clean. Prefer real refactors over suppressions.
+- Formatting is enforced only by the git pre-commit hook (`.githooks/pre-commit`: `oxfmt --write` + `oxlint --fix`), never in CI.
 
 ## PR Guidelines
 
-- Target branch: `master`
-- All CI checks must pass: lint, tests, build
-- Formatting is enforced locally by the git pre-commit hook (`.githooks/pre-commit`), not in CI; it runs `oxfmt --write` plus `oxlint --fix` on commit
-- Run `npm run validate` before submitting
+- Target branch: `master`. CI runs lint + tests + build; run `npm run validate` before submitting.
 
 ## Commit & Release Conventions
 
-- **All commits and PR titles must follow [Conventional Commits](https://www.conventionalcommits.org/)**: `type(scope): subject`, where `type` is one of `feat`, `fix`, `chore`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `revert`. Use `!` or a `BREAKING CHANGE:` footer for breaking changes.
-- This convention is enforced by the **PR Gate** workflow (`.github/workflows/pr-gate.yml`), which fails any PR whose title does not conform.
-- Releases are automated by [release-please](https://github.com/googleapis/release-please-action): merging Conventional Commits to `master` opens a release PR titled `chore(master): release ...`; merging it tags and publishes the release.
-- `CLAUDE.md` is a symlink to this file so Claude Code reads the same conventions.
+- Commits and PR titles must follow [Conventional Commits](https://www.conventionalcommits.org/) (`type(scope): subject`, breaking via `!` or `BREAKING CHANGE:` footer), enforced by the PR Gate workflow (`.github/workflows/pr-gate.yml`).
+- Releases via [release-please](https://github.com/googleapis/release-please-action): merging Conventional Commits to `master` opens a release PR titled `chore(master): release ...`; merging it tags and publishes.
+- `CLAUDE.md` is a symlink to this file.


### PR DESCRIPTION
## Summary

Three-way sync of the root intent node (current code <-> existing AGENTS.md <-> ideal node) against the last ~10 days of changes, with aggressive pruning to keep agent context small.

### Added
- **Code Standards section**: strict oxlint + ultracite anti-slop rules; `src/` must stay lint-clean, prefer real refactors over suppressions (#24).
- Bun 1.4 requirement (`engines`, CI pins 1.4.0) and dependency catalog pinning note (catalog-update automation) (#12).

### Modified
- Setup: `npm install` -> `bun install`; replaced npm/.npmrc pinning prose with Bun/catalog facts; 'Node.js >= 20' -> 'Bun >= 1.4' (superseded by bun adoption in #12/#20).
- Command table: `npm test` now 'Run Bun tests', no watch mode (vitest removed in bb4fb62 / #20).
- Testing: Vitest instructions -> `bun test` + `bun test -t "name"` filtering.
- Compressed commit/release conventions into dense bullets; CI = lint + tests + build stated once in PR Guidelines.

### Removed
- "Run Vitest in watch mode" / `npx vitest run` invocations — vitest deleted in #20 (bb4fb62); dead commands mislead agents.
- ".npmrc package-lock=false / save-exact=true" claims — npm-specific flags irrelevant under Bun; lockfile story is `bun.lock` + catalog pins + bunfig `exact = true`.
- Line-count annotations (~750 src / ~1000 test lines, "50+ cases") — instant-drift maintenance bait (src is already down to 495 lines after #24's rewrite).
- Duplicated type-list enumeration and 'CLAUDE.md reads the same conventions' verbosity — symlink line kept, one-liner suffices.

Validation: `npm run validate` passes (lint clean, 45/45 tests).