### PR TITLE
chore: enable strict oxlint rules and fix violations

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "./node_modules/oxlint/configuration_schema.json",
-	"plugins": ["typescript", "oxc", "unicorn", "import", "promise"],
+	"plugins": ["typescript", "oxc", "unicorn", "import", "promise", "react"],
 	"jsPlugins": [
 		{
 			"name": "anti-slop",
@@ -57,6 +57,14 @@
 		"no-var": "error",
 		"prefer-object-spread": "error",
 		"preserve-caught-error": "error",
+		"no-throw-literal": "error",
+		// `no-unused-vars` had `"variables": "off"` suggested as part of the strict-rule
+		// sweep, but oxlint only supports `vars: all|local` (no "off"), so the option
+		// is omitted rather than shipped as dead config; default `vars` checking stays on.
+		"no-unused-vars": [
+			"error",
+			{ "argsIgnorePattern": "^_", "fix": { "imports": "safe-fix" } }
+		],
 		"block-scoped-var": "error",
 		"guard-for-in": "error",
 		"no-case-declarations": "error",
@@ -82,11 +90,15 @@
 		"no-useless-call": "error",
 		"prefer-object-has-own": "error",
 		"prefer-regex-literals": "error",
-		// `multi-line` only: a brace-less body on its own line is a footgun, because oxfmt breaks
-		// a long single-line `if` at printWidth without adding braces. One-line `if (x) return y`
-		// stays legal.
-		"curly": ["error", "multi-line"],
-		"no-unexpected-multiline": "off",
+		// Full braces: a brace-less body on its own line is a footgun, because oxfmt
+		// breaks a long single-line `if` at printWidth without adding braces, and a
+		// brace-less multi-line body reads like two statements. One-line
+		// `if (x) return y` now also gets braces for consistency.
+		"curly": "error",
+		"no-unexpected-multiline": "error",
+		// Track the one release-blocking marker this repo uses. Generic TODOs are
+		// deliberate here; an unshipped-commit risk is not.
+		"no-warning-comments": ["error", { "terms": ["@nocommit"] }],
 		"no-else-return": ["error", { "allowElseIf": false }],
 		"no-lonely-if": "error",
 		"no-nested-ternary": "error",
@@ -94,17 +106,23 @@
 		"prefer-destructuring": ["error", { "array": false }],
 		"prefer-template": "error",
 		"default-param-last": "error",
-		"no-unused-vars": ["error", { "argsIgnorePattern": "^_" }],
 		"no-console": ["error", { "allow": ["warn", "error"] }],
 		// Module-level helpers are declarations, not arrow assignments: declaration hoisting
 		// keeps the mutually recursive traversal family (traverseKey <-> traverseArray/
 		// traverseMap/traverseSchema) readable without caring about definition order.
 		"func-style": ["error", "declaration"],
+		// Named function expressions keep a readable stack-trace name, so only the
+		// anonymous ones must become arrows.
+		"prefer-arrow-callback": ["error", { "allowNamedFunctions": true }],
 
 		"@typescript-eslint/ban-ts-comment": [
 			"error",
 			{ "minimumDescriptionLength": 10 }
 		],
+		// Generic `Array<T>` everywhere: the library already leans on nested array
+		// types (string[][], Map<string, string[]>), where postfix brackets get noisy
+		// and ambiguous.
+		"typescript/array-type": ["error", { "default": "generic" }],
 		"no-array-constructor": "error",
 		"@typescript-eslint/no-duplicate-enum-values": "error",
 		"@typescript-eslint/no-dynamic-delete": "error",
@@ -188,6 +206,7 @@
 		"unicorn/no-abusive-eslint-disable": "error",
 		"unicorn/no-await-expression-member": "error",
 		"unicorn/no-empty-file": "error",
+		"unicorn/no-hex-escape": "error",
 		// strict, not the default loose strategy: loose skips `Error` itself, which is the
 		// one builtin hand-rolled probes reach for most often.
 		"unicorn/no-instanceof-builtins": ["error", { "strategy": "strict" }],
@@ -207,7 +226,9 @@
 		"unicorn/numeric-separators-style": "error",
 		"unicorn/prefer-array-find": "error",
 		"unicorn/prefer-array-flat-map": "error",
+		"unicorn/prefer-array-index-of": "error",
 		"unicorn/prefer-array-some": "error",
+		"unicorn/prefer-at": "error",
 		"unicorn/prefer-date-now": "error",
 		"unicorn/prefer-logical-operator-over-ternary": "error",
 		"unicorn/prefer-native-coercion-functions": "error",
@@ -216,6 +237,7 @@
 		"unicorn/prefer-regexp-test": "error",
 		"unicorn/prefer-set-has": "error",
 		"unicorn/prefer-spread": "error",
+		"unicorn/prefer-string-raw": "error",
 		"unicorn/prefer-string-replace-all": "error",
 		"unicorn/prefer-string-slice": "error",
 		"unicorn/require-array-join-separator": "error",
@@ -237,12 +259,15 @@
 		"unicorn/no-useless-length-check": "error",
 		"unicorn/prefer-math-min-max": "error",
 		"unicorn/prefer-modern-math-apis": "error",
+		"unicorn/prefer-import-meta-properties": "error",
 		"unicorn/prefer-set-size": "error",
+		"unicorn/prefer-single-call": "error",
 		"unicorn/prefer-type-error": "error",
 		"unicorn/require-number-to-fixed-digits-argument": "error",
 		"unicorn/throw-new-error": "error",
 
 		"import/consistent-type-specifier-style": ["error", "prefer-inline"],
+		"import/export": "error",
 		"import/no-absolute-path": "error",
 		"import/no-cycle": "error",
 		"import/no-duplicates": "error",
@@ -283,6 +308,10 @@
 		"promise/prefer-catch": "error",
 		"promise/spec-only": "error",
 		"promise/valid-params": "error",
+
+		// The repo ships no React code today; the rule stays armed so a future
+		// component cannot regress into a render method that returns nothing.
+		"react/require-render-return": "error",
 
 		// anti-slop (upstream dmmulroy/anti-slop, vendored by ultracite).
 		"anti-slop/no-chained-type-assertions": "error",

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,15 +42,15 @@ class UnsupportedTypeException extends Error {
 }
 
 type ProtobufField = {
-	types: string[]
+	types: Array<string>
 	name: string
-	oneofMembers?: ProtobufField[]
+	oneofMembers?: Array<ProtobufField>
 }
 
 /** Shared state threaded through the whole conversion traversal. */
 type Context = {
-	messages: Map<string, string[]>
-	enums: Map<string, string[]>
+	messages: Map<string, Array<string>>
+	enums: Map<string, Array<string>>
 	typePrefix: string
 	useGoogleTimestamp: boolean
 	hasTimestamp: boolean
@@ -105,8 +105,8 @@ function renderFieldType(field: ProtobufField): string {
  * @param fields The ProtobufField array.
  * @returns An array of formatted field strings.
  */
-function formatFields(fields: ProtobufField[]): string[] {
-	const lines: string[] = []
+function formatFields(fields: Array<ProtobufField>): Array<string> {
+	const lines: Array<string> = []
 	let fieldNum = 1
 	for (const field of fields) {
 		if (field.oneofMembers) {
@@ -132,15 +132,33 @@ function formatFields(fields: ProtobufField[]): string[] {
  * @returns A short string suffix.
  */
 function getOneofTypeSuffix(value: $ZodType): string {
-	if (value instanceof ZodString) return 'string'
-	if (value instanceof ZodNumber) return getNumberTypeName(value)
-	if (value instanceof ZodBoolean) return 'bool'
-	if (value instanceof ZodBigInt) return 'int64'
-	if (value instanceof ZodDate) return 'date'
-	if (value instanceof ZodObject) return 'message'
-	if (value instanceof ZodArray || value instanceof ZodSet) return 'list'
-	if (value instanceof ZodEnum) return 'enum'
-	if (value instanceof ZodLiteral) return 'literal'
+	if (value instanceof ZodString) {
+		return 'string'
+	}
+	if (value instanceof ZodNumber) {
+		return getNumberTypeName(value)
+	}
+	if (value instanceof ZodBoolean) {
+		return 'bool'
+	}
+	if (value instanceof ZodBigInt) {
+		return 'int64'
+	}
+	if (value instanceof ZodDate) {
+		return 'date'
+	}
+	if (value instanceof ZodObject) {
+		return 'message'
+	}
+	if (value instanceof ZodArray || value instanceof ZodSet) {
+		return 'list'
+	}
+	if (value instanceof ZodEnum) {
+		return 'enum'
+	}
+	if (value instanceof ZodLiteral) {
+		return 'literal'
+	}
 	return 'value'
 }
 
@@ -160,11 +178,15 @@ function getLiteralTypeName(value: ZodLiteral): string {
 	 * earlier to parse against.
 	 */
 	const first = value.values.values().next().value
-	if (typeof first === 'string') return 'string'
+	if (typeof first === 'string') {
+		return 'string'
+	}
 	if (typeof first === 'number') {
 		return Number.isInteger(first) ? 'int32' : 'double'
 	}
-	if (typeof first === 'boolean') return 'bool'
+	if (typeof first === 'boolean') {
+		return 'bool'
+	}
 	throw new UnsupportedTypeException(`ZodLiteral(${typeof first})`)
 	/* oxlint-enable anti-slop/no-runtime-typeof */
 }
@@ -177,11 +199,21 @@ function getLiteralTypeName(value: ZodLiteral): string {
  * @returns The Protobuf scalar type name, or undefined.
  */
 function getScalarTypeName(value: $ZodType): string | undefined {
-	if (value instanceof ZodString) return 'string'
-	if (value instanceof ZodBoolean) return 'bool'
-	if (value instanceof ZodBigInt) return 'int64'
-	if (value instanceof ZodNumber) return getNumberTypeName(value)
-	if (value instanceof ZodLiteral) return getLiteralTypeName(value)
+	if (value instanceof ZodString) {
+		return 'string'
+	}
+	if (value instanceof ZodBoolean) {
+		return 'bool'
+	}
+	if (value instanceof ZodBigInt) {
+		return 'int64'
+	}
+	if (value instanceof ZodNumber) {
+		return getNumberTypeName(value)
+	}
+	if (value instanceof ZodLiteral) {
+		return getLiteralTypeName(value)
+	}
 	return undefined
 }
 
@@ -208,7 +240,7 @@ function toRepeatedField(field: ProtobufField, key: string): ProtobufField {
  * Asserts a traversal produced exactly one plain field and returns it, so
  * map/record sides can safely be rendered as a scalar map<...> entry.
  */
-function soleField(fields: ProtobufField[], label: string): ProtobufField {
+function soleField(fields: Array<ProtobufField>, label: string): ProtobufField {
 	const [only] = fields
 	if (only === undefined || fields.length !== 1) {
 		throw new UnsupportedTypeException(label)
@@ -283,7 +315,7 @@ function traverseArray(
 	key: string,
 	value: ZodArray | ZodSet,
 	context: Context
-): ProtobufField[] {
+): Array<ProtobufField> {
 	const nestedValue =
 		value instanceof ZodArray ? value.element : value.def.valueType
 	const unwrapped = unwrap(nestedValue)
@@ -327,7 +359,7 @@ function traverseKey(
 	value: $ZodType,
 	isInArray: boolean,
 	context: Context
-): ProtobufField[] {
+): Array<ProtobufField> {
 	const { core, optional } = unwrap(value)
 
 	if (core instanceof ZodArray || core instanceof ZodSet) {
@@ -345,7 +377,7 @@ function traverseKey(
 	}
 
 	if (core instanceof ZodUnion || core instanceof ZodDiscriminatedUnion) {
-		const members: ProtobufField[] = []
+		const members: Array<ProtobufField> = []
 		const usedSuffixes = new Set<string>()
 
 		for (const option of core.options) {
@@ -404,8 +436,8 @@ function traverseKey(
 	}
 
 	if (core instanceof ZodTuple) {
-		const tupleFields: ProtobufField[] = core.def.items.flatMap((item, index) =>
-			traverseKey(`${key}_${index}`, item, isInArray, context)
+		const tupleFields: Array<ProtobufField> = core.def.items.flatMap(
+			(item, index) => traverseKey(`${key}_${index}`, item, isInArray, context)
 		)
 
 		const tupleMessageName = `${context.typePrefix}${toPascalCase(key)}`
@@ -426,7 +458,7 @@ function traverseKey(
  * @param context Shared traversal state.
  * @returns An array of formatted Protobuf field strings.
  */
-function traverseSchema(schema: $ZodType, context: Context): string[] {
+function traverseSchema(schema: $ZodType, context: Context): Array<string> {
 	if (!(schema instanceof ZodObject)) {
 		throw new UnsupportedTypeException(schema.constructor.name)
 	}
@@ -456,8 +488,8 @@ function zodToProtobuf(
 	} = options
 
 	const context: Context = {
-		messages: new Map<string, string[]>(),
-		enums: new Map<string, string[]>(),
+		messages: new Map<string, Array<string>>(),
+		enums: new Map<string, Array<string>>(),
 		typePrefix,
 		useGoogleTimestamp,
 		hasTimestamp: false


### PR DESCRIPTION
## Summary

Enables a batch of strict oxlint rules and fixes every new finding. No disable directives, no severity downgrades, no unrelated refactors.

## Rules enabled (all at `"error"`)

- `no-throw-literal`
- `no-unexpected-multiline` (was explicitly `"off"` in this config)
- `no-warning-comments` — `["error", { "terms": ["@nocommit"] }]`
- `import/export`
- `react/require-render-return` (required adding the `react` plugin to `plugins`)
- `unicorn/prefer-array-index-of`
- `unicorn/prefer-optional-catch-binding`
- `curly` — was `["error", "multi-line"]`, changed to plain `"error"` per spec
- `typescript/array-type` — `["error", { "default": "generic" }]`
- `unicorn/no-hex-escape`
- `unicorn/prefer-single-call`
- `unicorn/prefer-at`
- `unicorn/prefer-string-raw`
- `eslint/prefer-arrow-callback` — `["error", { "allowNamedFunctions": true }]`
- `no-unused-vars` — `["error", { "argsIgnorePattern": "^_", "fix": { "imports": "safe-fix" } }]`
- `unicorn/prefer-import-meta-properties`

## Findings fixed

- **31 findings across 1 file** (`src/index.ts`; the test file was already clean):
  - 16 × `curly` — single-line brace-less `if (...) return ...` bodies in `getOneofTypeSuffix`, `getLiteralTypeName`, and `getScalarTypeName` now use explicit blocks.
  - 15 × `typescript/array-type` — postfix array types (`string[]`, `ProtobufField[]`, `Map<string, string[]>`) rewritten to generic syntax (`Array<T>`, `ReadonlyArray<T>`).
- The remaining enabled rules (`no-throw-literal`, `no-warning-comments`, `import/export`, `react/require-render-return`, `unicorn/prefer-array-index-of`, `unicorn/prefer-optional-catch-binding`, `unicorn/no-hex-escape`, `unicorn/prefer-single-call`, `unicorn/prefer-at`, `unicorn/prefer-string-raw`, `unicorn/prefer-import-meta-properties`) produced **zero findings** — they are armed for regressions.

## Skipped rules

None — every requested rule name is known to oxlint 1.79.0 (the pinned version; no upgrade needed).

## Config substitutions

- `no-unused-vars`: the spec's `"variables": "off"` is **not supported by oxlint** (its `vars` option only accepts `"all"` / `"local"`, and the unknown key is silently ignored — verified by probe). Rather than ship dead config or weaken the rule, the option is omitted, keeping oxlint's default `vars: all` checking (unchanged from the previous config).
- The "unused imports fixable via safe fixes only" requirement **is** natively supported: added `"fix": { "imports": "safe-fix" }` to `no-unused-vars` (oxlint's fix-mode option for unused-import auto-fixes).

## Validation

- `npm run lint` (type-aware): 0 warnings, 0 errors (371 rules active)
- `npm test`: 47 pass, 0 fail
- `npm run build` (`tsc`): clean
