### PR TITLE
ci: use CI_PAT for catalog-update checkout

### DIFF
--- a/.github/workflows/catalog-update.yml
+++ b/.github/workflows/catalog-update.yml
@@ -15,6 +15,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          # A PAT (not the default GITHUB_TOKEN) so branch updates are
+          # attributed to a real user and CI runs without manual approval.
+          token: ${{ secrets.CI_PAT }}
 
       - uses: brandhaug/catalog-update-action@v1
         with:

--- a/package.json
+++ b/package.json
@@ -1,71 +1,71 @@
 {
-  "name": "zod-to-protobuf",
-  "version": "2.10.3",
-  "description": "A utility to convert Zod schemas to Protocol Buffers definitions.",
-  "keywords": [
-    "conversion",
-    "protobuf",
-    "schema",
-    "typescript",
-    "zod"
-  ],
-  "homepage": "https://github.com/brandhaug/zod-to-protobuf#readme",
-  "bugs": {
-    "url": "https://github.com/brandhaug/zod-to-protobuf/issues"
-  },
-  "license": "MIT",
-  "author": "Martin Brandhaug",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/brandhaug/zod-to-protobuf.git"
-  },
-  "workspaces": [],
-  "files": [
-    "dist/"
-  ],
-  "type": "module",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
-  "exports": {
-    ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
-    }
-  },
-  "scripts": {
-    "build": "tsc",
-    "start": "node dist/index.js",
-    "lint": "oxlint --type-aware",
-    "format": "oxfmt --write",
-    "prepare": "git config core.hooksPath .githooks",
-    "test": "bun test",
-    "validate": "npm run lint && npm run test"
-  },
-  "dependencies": {
-    "inflection": "3.0.2"
-  },
-  "devDependencies": {
-    "@types/node": "catalog:",
-    "oxfmt": "catalog:",
-    "oxlint": "catalog:",
-    "oxlint-tsgolint": "catalog:",
-    "typescript": "catalog:",
-    "ultracite": "catalog:"
-  },
-  "peerDependencies": {
-    "zod": "^4.0.0"
-  },
-  "engines": {
-    "bun": ">=1.4.0"
-  },
-  "packageManager": "bun@1.4.0",
-  "catalog": {
-    "@types/node": "26.3.0",
-    "inflection": "3.0.2",
-    "oxfmt": "0.65.0",
-    "oxlint": "1.79.0",
-    "oxlint-tsgolint": "7.0.2001",
-    "typescript": "7.0.2",
-    "ultracite": "7.10.6"
-  }
+	"name": "zod-to-protobuf",
+	"version": "2.10.3",
+	"description": "A utility to convert Zod schemas to Protocol Buffers definitions.",
+	"keywords": [
+		"conversion",
+		"protobuf",
+		"schema",
+		"typescript",
+		"zod"
+	],
+	"homepage": "https://github.com/brandhaug/zod-to-protobuf#readme",
+	"bugs": {
+		"url": "https://github.com/brandhaug/zod-to-protobuf/issues"
+	},
+	"license": "MIT",
+	"author": "Martin Brandhaug",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/brandhaug/zod-to-protobuf.git"
+	},
+	"workspaces": [],
+	"files": [
+		"dist/"
+	],
+	"type": "module",
+	"main": "dist/index.js",
+	"types": "dist/index.d.ts",
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js"
+		}
+	},
+	"scripts": {
+		"build": "tsc",
+		"start": "node dist/index.js",
+		"lint": "oxlint --type-aware",
+		"format": "oxfmt --write",
+		"prepare": "git config core.hooksPath .githooks",
+		"test": "bun test",
+		"validate": "npm run lint && npm run test"
+	},
+	"dependencies": {
+		"inflection": "3.0.2"
+	},
+	"devDependencies": {
+		"@types/node": "catalog:",
+		"oxfmt": "catalog:",
+		"oxlint": "catalog:",
+		"oxlint-tsgolint": "catalog:",
+		"typescript": "catalog:",
+		"ultracite": "catalog:"
+	},
+	"peerDependencies": {
+		"zod": "^4.0.0"
+	},
+	"engines": {
+		"bun": ">=1.4.0"
+	},
+	"packageManager": "bun@1.4.0",
+	"catalog": {
+		"@types/node": "26.3.0",
+		"inflection": "3.0.2",
+		"oxfmt": "0.65.0",
+		"oxlint": "1.79.0",
+		"oxlint-tsgolint": "7.0.2001",
+		"typescript": "7.0.2",
+		"ultracite": "7.10.6"
+	}
 }


### PR DESCRIPTION
## Problem

CI and PR Gate workflows on `catalog-update/*` PRs get stuck in `action_required` (awaiting approval) whenever the catalog-update action pushes updates to an existing update branch. The checkout step uses the default `GITHUB_TOKEN`, so those pushes are attributed to `github-actions[bot]`, and GitHub requires manual approval for workflow runs triggered by it.

## Fix

Authenticate `actions/checkout` with `CI_PAT` (same as the action step already does) so branch updates are attributed to a real user and CI runs automatically. Matches the setup already in place in `b2b-saas-starter`.
