### PR TITLE
ci: rebuild update PRs on push to master

### DIFF
--- a/.github/workflows/catalog-update.yml
+++ b/.github/workflows/catalog-update.yml
@@ -3,7 +3,19 @@ name: Catalog Update
 on:
   schedule:
     - cron: '0 6 * * *'
+  push:
+    branches:
+      - master
+    paths:
+      - '**/package.json'
+      - '**/bun.lock'
   workflow_dispatch:
+
+# Rebuilds of open update PRs must run one at a time; queued (not cancelled)
+# runs are what let the cascade converge after each merge.
+concurrency:
+  group: catalog-update
+  cancel-in-progress: false
 
 jobs:
   update:

--- a/package.json
+++ b/package.json
@@ -1,71 +1,71 @@
 {
-  "name": "zod-to-protobuf",
-  "version": "2.10.3",
-  "description": "A utility to convert Zod schemas to Protocol Buffers definitions.",
-  "keywords": [
-    "conversion",
-    "protobuf",
-    "schema",
-    "typescript",
-    "zod"
-  ],
-  "homepage": "https://github.com/brandhaug/zod-to-protobuf#readme",
-  "bugs": {
-    "url": "https://github.com/brandhaug/zod-to-protobuf/issues"
-  },
-  "license": "MIT",
-  "author": "Martin Brandhaug",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/brandhaug/zod-to-protobuf.git"
-  },
-  "workspaces": [],
-  "files": [
-    "dist/"
-  ],
-  "type": "module",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
-  "exports": {
-    ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
-    }
-  },
-  "scripts": {
-    "build": "tsc",
-    "start": "node dist/index.js",
-    "lint": "oxlint --type-aware",
-    "format": "oxfmt --write",
-    "prepare": "git config core.hooksPath .githooks",
-    "test": "bun test",
-    "validate": "npm run lint && npm run test"
-  },
-  "dependencies": {
-    "inflection": "3.0.2"
-  },
-  "devDependencies": {
-    "@types/node": "catalog:",
-    "oxfmt": "catalog:",
-    "oxlint": "catalog:",
-    "oxlint-tsgolint": "catalog:",
-    "typescript": "catalog:",
-    "ultracite": "catalog:"
-  },
-  "peerDependencies": {
-    "zod": "^4.0.0"
-  },
-  "engines": {
-    "bun": ">=1.4.0"
-  },
-  "packageManager": "bun@1.4.0",
-  "catalog": {
-    "@types/node": "26.4.0",
-    "inflection": "3.0.2",
-    "oxfmt": "0.65.0",
-    "oxlint": "1.80.0",
-    "oxlint-tsgolint": "7.0.2001",
-    "typescript": "7.0.2",
-    "ultracite": "7.10.7"
-  }
+	"name": "zod-to-protobuf",
+	"version": "2.10.3",
+	"description": "A utility to convert Zod schemas to Protocol Buffers definitions.",
+	"keywords": [
+		"conversion",
+		"protobuf",
+		"schema",
+		"typescript",
+		"zod"
+	],
+	"homepage": "https://github.com/brandhaug/zod-to-protobuf#readme",
+	"bugs": {
+		"url": "https://github.com/brandhaug/zod-to-protobuf/issues"
+	},
+	"license": "MIT",
+	"author": "Martin Brandhaug",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/brandhaug/zod-to-protobuf.git"
+	},
+	"workspaces": [],
+	"files": [
+		"dist/"
+	],
+	"type": "module",
+	"main": "dist/index.js",
+	"types": "dist/index.d.ts",
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js"
+		}
+	},
+	"scripts": {
+		"build": "tsc",
+		"start": "node dist/index.js",
+		"lint": "oxlint --type-aware",
+		"format": "oxfmt --write",
+		"prepare": "git config core.hooksPath .githooks",
+		"test": "bun test",
+		"validate": "npm run lint && npm run test"
+	},
+	"dependencies": {
+		"inflection": "3.0.2"
+	},
+	"devDependencies": {
+		"@types/node": "catalog:",
+		"oxfmt": "catalog:",
+		"oxlint": "catalog:",
+		"oxlint-tsgolint": "catalog:",
+		"typescript": "catalog:",
+		"ultracite": "catalog:"
+	},
+	"peerDependencies": {
+		"zod": "^4.0.0"
+	},
+	"engines": {
+		"bun": ">=1.4.0"
+	},
+	"packageManager": "bun@1.4.0",
+	"catalog": {
+		"@types/node": "26.4.0",
+		"inflection": "3.0.2",
+		"oxfmt": "0.65.0",
+		"oxlint": "1.80.0",
+		"oxlint-tsgolint": "7.0.2001",
+		"typescript": "7.0.2",
+		"ultracite": "7.10.7"
+	}
 }


### PR DESCRIPTION
## Problem 1: conflicting update PRs could never be rebuilt

`hasNonBotCommits` skipped any PR containing a commit not authored by `github-actions[bot]`. GitHub's "Update branch" button (and `gh pr update-branch`) adds a merge commit authored by a human, which permanently poisoned the PR — the action would never rebuild it again, so a conflicted update PR stayed conflicted forever.

Commits are now fetched via the REST API (`gh api repos/{owner}/{repo}/pulls/N/commits`) so merge commits (2+ parents) can be identified and ignored. Only human-authored **non-merge** commits trigger the skip. Covered by new unit tests in `test/git.test.ts`.

## Problem 2: waiting until the next day for rebuilds

The workflow only ran on `schedule`/`workflow_dispatch`, so after a merge invalidated the other open update PRs, nothing rebuilt them until the next morning.

Adds a `push` trigger (paths: `**/package.json`, `**/bun.lock`) with a non-cancelling `concurrency` group so open PRs are rebuilt immediately after every merge to master. With auto-merge enabled this cascades: merge → rebuild → CI → merge → … until all groups are up to date, same day. README recipe updated to match.
