### PR TITLE
ci: add fallow dead-code regression gate

### DIFF
--- a/.fallowrc.json
+++ b/.fallowrc.json
@@ -1,0 +1,41 @@
+{
+	"$schema": "https://raw.githubusercontent.com/fallow-rs/fallow/main/schema.json",
+	"regression": {
+		"baseline": {
+			"analysisIdentity": {
+				"mode": "syntactic",
+				"semantic_schema_version": 1,
+				"capabilities": [],
+				"project_config_hash": "",
+				"backend_family": "",
+				"completeness": "complete"
+			},
+			"totalIssues": 3,
+			"unusedFiles": 1,
+			"unusedExports": 0,
+			"unusedTypes": 0,
+			"unusedDependencies": 0,
+			"unusedDevDependencies": 1,
+			"unusedOptionalDependencies": 0,
+			"unusedEnumMembers": 0,
+			"unusedClassMembers": 0,
+			"unresolvedImports": 0,
+			"unlistedDependencies": 0,
+			"duplicateExports": 0,
+			"circularDependencies": 0,
+			"reExportCycles": 0,
+			"typeOnlyDependencies": 0,
+			"testOnlyDependencies": 0,
+			"devDependenciesInProduction": 0,
+			"boundaryViolations": 0,
+			"boundaryCoverageViolations": 0,
+			"boundaryCallViolations": 0,
+			"policyViolations": 0
+		}
+	},
+	"rules": {
+		"unused-catalog-entries": "warn",
+		"unused-dependencies": "warn",
+		"unused-files": "warn"
+	}
+}

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -30,3 +30,13 @@ jobs:
             ci
             revert
           requireSubject: true
+
+  fallow-dead-code:
+    name: Fallow dead-code regression
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+      - run: bun install --frozen-lockfile
+      - run: npm install -g fallow@3
+      - run: bun run dead-code

--- a/package.json
+++ b/package.json
@@ -1,71 +1,72 @@
 {
-  "name": "zod-to-protobuf",
-  "version": "2.10.3",
-  "description": "A utility to convert Zod schemas to Protocol Buffers definitions.",
-  "keywords": [
-    "conversion",
-    "protobuf",
-    "schema",
-    "typescript",
-    "zod"
-  ],
-  "homepage": "https://github.com/brandhaug/zod-to-protobuf#readme",
-  "bugs": {
-    "url": "https://github.com/brandhaug/zod-to-protobuf/issues"
-  },
-  "license": "MIT",
-  "author": "Martin Brandhaug",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/brandhaug/zod-to-protobuf.git"
-  },
-  "workspaces": [],
-  "files": [
-    "dist/"
-  ],
-  "type": "module",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
-  "exports": {
-    ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
-    }
-  },
-  "scripts": {
-    "build": "tsc",
-    "start": "node dist/index.js",
-    "lint": "oxlint --type-aware",
-    "format": "oxfmt --write",
-    "prepare": "git config core.hooksPath .githooks",
-    "test": "bun test",
-    "validate": "npm run lint && npm run test"
-  },
-  "dependencies": {
-    "inflection": "3.0.2"
-  },
-  "devDependencies": {
-    "@types/node": "catalog:",
-    "oxfmt": "catalog:",
-    "oxlint": "catalog:",
-    "oxlint-tsgolint": "catalog:",
-    "typescript": "catalog:",
-    "ultracite": "catalog:"
-  },
-  "peerDependencies": {
-    "zod": "^4.0.0"
-  },
-  "engines": {
-    "bun": ">=1.4.0"
-  },
-  "packageManager": "bun@1.4.0",
-  "catalog": {
-    "@types/node": "26.4.0",
-    "inflection": "3.0.2",
-    "oxfmt": "0.65.0",
-    "oxlint": "1.80.0",
-    "oxlint-tsgolint": "7.0.2001",
-    "typescript": "7.0.2",
-    "ultracite": "7.10.7"
-  }
+	"name": "zod-to-protobuf",
+	"version": "2.10.3",
+	"description": "A utility to convert Zod schemas to Protocol Buffers definitions.",
+	"keywords": [
+		"conversion",
+		"protobuf",
+		"schema",
+		"typescript",
+		"zod"
+	],
+	"homepage": "https://github.com/brandhaug/zod-to-protobuf#readme",
+	"bugs": {
+		"url": "https://github.com/brandhaug/zod-to-protobuf/issues"
+	},
+	"license": "MIT",
+	"author": "Martin Brandhaug",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/brandhaug/zod-to-protobuf.git"
+	},
+	"workspaces": [],
+	"files": [
+		"dist/"
+	],
+	"type": "module",
+	"main": "dist/index.js",
+	"types": "dist/index.d.ts",
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js"
+		}
+	},
+	"scripts": {
+		"build": "tsc",
+		"start": "node dist/index.js",
+		"lint": "oxlint --type-aware",
+		"format": "oxfmt --write",
+		"prepare": "git config core.hooksPath .githooks",
+		"test": "bun test",
+		"dead-code": "fallow dead-code --fail-on-regression",
+		"validate": "npm run lint && npm run test && npm run dead-code"
+	},
+	"dependencies": {
+		"inflection": "3.0.2"
+	},
+	"devDependencies": {
+		"@types/node": "catalog:",
+		"oxfmt": "catalog:",
+		"oxlint": "catalog:",
+		"oxlint-tsgolint": "catalog:",
+		"typescript": "catalog:",
+		"ultracite": "catalog:"
+	},
+	"peerDependencies": {
+		"zod": "^4.0.0"
+	},
+	"engines": {
+		"bun": ">=1.4.0"
+	},
+	"packageManager": "bun@1.4.0",
+	"catalog": {
+		"@types/node": "26.4.0",
+		"inflection": "3.0.2",
+		"oxfmt": "0.65.0",
+		"oxlint": "1.80.0",
+		"oxlint-tsgolint": "7.0.2001",
+		"typescript": "7.0.2",
+		"ultracite": "7.10.7"
+	}
 }


### PR DESCRIPTION
Adds [fallow](https://www.npmjs.com/package/fallow) dead-code analysis:

- `dead-code` script running `fallow dead-code --fail-on-regression`
- chained into `validate` (where present)
- `fallow-dead-code` job in the PR Gate workflow
- `.fallowrc.json` with the current issue counts as the regression baseline (existing findings are warn-level; only regressions fail CI)