### PR TITLE
chore: remove dead code and unused dependencies surfaced by fallow

### DIFF
--- a/.fallowrc.json
+++ b/.fallowrc.json
@@ -1,5 +1,8 @@
 {
+	// ultracite is used: .oxlintrc.json loads its bundled anti-slop plugin via a
+	// node_modules path specifier, which static analysis cannot see as a usage.
 	"$schema": "https://raw.githubusercontent.com/fallow-rs/fallow/main/schema.json",
+	"ignoreDependencies": ["ultracite"],
 	"regression": {
 		"baseline": {
 			"analysisIdentity": {
@@ -10,12 +13,12 @@
 				"backend_family": "",
 				"completeness": "complete"
 			},
-			"totalIssues": 3,
-			"unusedFiles": 1,
+			"totalIssues": 0,
+			"unusedFiles": 0,
 			"unusedExports": 0,
 			"unusedTypes": 0,
 			"unusedDependencies": 0,
-			"unusedDevDependencies": 1,
+			"unusedDevDependencies": 0,
 			"unusedOptionalDependencies": 0,
 			"unusedEnumMembers": 0,
 			"unusedClassMembers": 0,
@@ -32,10 +35,5 @@
 			"boundaryCallViolations": 0,
 			"policyViolations": 0
 		}
-	},
-	"rules": {
-		"unused-catalog-entries": "warn",
-		"unused-dependencies": "warn",
-		"unused-files": "warn"
 	}
 }

--- a/bun.lock
+++ b/bun.lock
@@ -22,7 +22,6 @@
   },
   "catalog": {
     "@types/node": "26.4.0",
-    "inflection": "3.0.2",
     "oxfmt": "0.65.0",
     "oxlint": "1.80.0",
     "oxlint-tsgolint": "7.0.2001",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
 	"packageManager": "bun@1.4.0",
 	"catalog": {
 		"@types/node": "26.4.0",
-		"inflection": "3.0.2",
 		"oxfmt": "0.65.0",
 		"oxlint": "1.80.0",
 		"oxlint-tsgolint": "7.0.2001",

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,3 +1,4 @@
+// fallow-ignore-file unused-file
 import { describe, expect, it } from 'bun:test'
 import { z } from 'zod'
 import {


### PR DESCRIPTION
Drives the fallow dead-code findings from 3 to 0.

**Deleted:**
- Removed the unused `inflection` entry from the Bun `catalog` block in `package.json`. The `inflection` runtime dependency itself is used (`src/index.ts`) but pins `3.0.2` directly — no `catalog:` reference exists anywhere, so the catalog entry was redundant.

**Suppressed (false positives):**
- `test/index.test.ts` (`unused-file`): the suite is discovered and run by `bun test` (47 tests pass); nothing imports it statically. Suppressed with `// fallow-ignore-file unused-file` at the top of the file.
- `ultracite` dev dependency (`unused-dev-dependency`): actually used — `.oxlintrc.json` loads ultracite's bundled anti-slop plugin via the path specifier `./node_modules/ultracite/config/oxlint/anti-slop/plugin.mjs`, which static analysis cannot observe. Added `ultracite` to `ignoreDependencies` in `.fallowrc.json` (reason documented in an inline comment; the schema's `ignoreDependencies` is a plain string array).

**Config cleanup:**
- Removed the `rules` block from `.fallowrc.json` and regenerated the regression baseline, which is now a single `regression` key with `totalIssues: 0`.

**Validation:** `fallow dead-code --fail-on-regression` exits 0 with 0 issues; `npm run validate` (oxlint + bun test + dead-code) passes; `oxfmt --check` clean.