### PR TITLE
ci: enforce circular-dependencies at error

### DIFF
--- a/.fallowrc.json
+++ b/.fallowrc.json
@@ -2,6 +2,9 @@
 	// ultracite is used: .oxlintrc.json loads its bundled anti-slop plugin via a
 	// node_modules path specifier, which static analysis cannot see as a usage.
 	"$schema": "https://raw.githubusercontent.com/fallow-rs/fallow/main/schema.json",
+	"rules": {
+		"circular-dependencies": "error"
+	},
 	"ignoreDependencies": ["ultracite"],
 	"regression": {
 		"baseline": {


### PR DESCRIPTION
Adds `"circular-dependencies": "error"` to the fallow rules so any import cycle fails the PR Gate.

All repos currently measure **0 circular dependencies** (verified in the recent fallow sweeps), so this is a free regression gate — no baseline machinery needed.