### PR TITLE
chore: upgrade bun to 1.4.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.4.0
+          bun-version: 1.4.2
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.4.0
+          bun-version: 1.4.2
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@
 bun install
 ```
 
-**Bun >= 1.4 required** (`engines`, CI pins 1.4.0). Dependency versions are pinned via the `catalog` block in `package.json`; dep bumps flow through the catalog-update automation.
+**Bun >= 1.4 required** (`engines`, CI pins 1.4.2). Dependency versions are pinned via the `catalog` block in `package.json`; dep bumps flow through the catalog-update automation.
 
 ## Development Commands
 

--- a/package.json
+++ b/package.json
@@ -1,71 +1,71 @@
 {
-  "name": "zod-to-protobuf",
-  "version": "2.10.4",
-  "description": "A utility to convert Zod schemas to Protocol Buffers definitions.",
-  "keywords": [
-    "conversion",
-    "protobuf",
-    "schema",
-    "typescript",
-    "zod"
-  ],
-  "homepage": "https://github.com/brandhaug/zod-to-protobuf#readme",
-  "bugs": {
-    "url": "https://github.com/brandhaug/zod-to-protobuf/issues"
-  },
-  "license": "MIT",
-  "author": "Martin Brandhaug",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/brandhaug/zod-to-protobuf.git"
-  },
-  "workspaces": [],
-  "files": [
-    "dist/"
-  ],
-  "type": "module",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
-  "exports": {
-    ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
-    }
-  },
-  "scripts": {
-    "build": "tsc",
-    "start": "node dist/index.js",
-    "lint": "oxlint --type-aware",
-    "format": "oxfmt --write",
-    "prepare": "git config core.hooksPath .githooks",
-    "test": "bun test",
-    "dead-code": "fallow dead-code --fail-on-regression",
-    "validate": "npm run lint && npm run test && npm run dead-code"
-  },
-  "dependencies": {
-    "inflection": "3.0.2"
-  },
-  "devDependencies": {
-    "@types/node": "catalog:",
-    "oxfmt": "catalog:",
-    "oxlint": "catalog:",
-    "oxlint-tsgolint": "catalog:",
-    "typescript": "catalog:",
-    "ultracite": "catalog:"
-  },
-  "peerDependencies": {
-    "zod": "^4.0.0"
-  },
-  "engines": {
-    "bun": ">=1.4.0"
-  },
-  "packageManager": "bun@1.4.0",
-  "catalog": {
-    "@types/node": "26.4.1",
-    "oxfmt": "0.66.0",
-    "oxlint": "1.81.0",
-    "oxlint-tsgolint": "7.0.2001",
-    "typescript": "7.0.2",
-    "ultracite": "7.10.7"
-  }
+	"name": "zod-to-protobuf",
+	"version": "2.10.4",
+	"description": "A utility to convert Zod schemas to Protocol Buffers definitions.",
+	"keywords": [
+		"conversion",
+		"protobuf",
+		"schema",
+		"typescript",
+		"zod"
+	],
+	"homepage": "https://github.com/brandhaug/zod-to-protobuf#readme",
+	"bugs": {
+		"url": "https://github.com/brandhaug/zod-to-protobuf/issues"
+	},
+	"license": "MIT",
+	"author": "Martin Brandhaug",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/brandhaug/zod-to-protobuf.git"
+	},
+	"workspaces": [],
+	"files": [
+		"dist/"
+	],
+	"type": "module",
+	"main": "dist/index.js",
+	"types": "dist/index.d.ts",
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js"
+		}
+	},
+	"scripts": {
+		"build": "tsc",
+		"start": "node dist/index.js",
+		"lint": "oxlint --type-aware",
+		"format": "oxfmt --write",
+		"prepare": "git config core.hooksPath .githooks",
+		"test": "bun test",
+		"dead-code": "fallow dead-code --fail-on-regression",
+		"validate": "npm run lint && npm run test && npm run dead-code"
+	},
+	"dependencies": {
+		"inflection": "3.0.2"
+	},
+	"devDependencies": {
+		"@types/node": "catalog:",
+		"oxfmt": "catalog:",
+		"oxlint": "catalog:",
+		"oxlint-tsgolint": "catalog:",
+		"typescript": "catalog:",
+		"ultracite": "catalog:"
+	},
+	"peerDependencies": {
+		"zod": "^4.0.0"
+	},
+	"engines": {
+		"bun": ">=1.4.2"
+	},
+	"packageManager": "bun@1.4.2",
+	"catalog": {
+		"@types/node": "26.4.1",
+		"oxfmt": "0.66.0",
+		"oxlint": "1.81.0",
+		"oxlint-tsgolint": "7.0.2001",
+		"typescript": "7.0.2",
+		"ultracite": "7.10.7"
+	}
 }


### PR DESCRIPTION
Upgrades the pinned Bun version from 1.4.0 to 1.4.2.

- `package.json`: `packageManager` bumped to `bun@1.4.2`
- `package.json`: `engines.bun` bumped to ">=1.4.2"
- `.github/workflows/ci.yml`: `bun-version` pin bumped to 1.4.2
- `.github/workflows/release.yml`: `bun-version` pin bumped to 1.4.2
- `AGENTS.md`: documented pin updated to 1.4.2

Note: `@types/bun` stays at 1.4.0 — 1.4.2 is not published on npm.